### PR TITLE
Update reference description

### DIFF
--- a/reference/create-transaction.mdx
+++ b/reference/create-transaction.mdx
@@ -26,7 +26,7 @@ Basic authentication header of the form — `Basic <encoded-value>`, where `<enc
   Precision for the transaction's currency. See also: [Precision](/transactions/precision).
 </ParamField>
 <ParamField body="reference" type="string" required>
-  The unique transaction reference number for the transaction. If empty, Blnk auto-creates one.
+  The unique transaction reference number for the transaction.
 </ParamField>
 <ParamField body="source" type="string" required>
   The balance sending the amount. `@` prefix indicates that the balance is an [internal balance](/balances/internal-balances).


### PR DESCRIPTION
Updated reference field description to match the actual behavior by Blnk (if it is left blank, an error occurs)