### PR TITLE
docs: Add v0.13.4 changelog entry (reconciliation improvements, logic…

### DIFF
--- a/changelog/blnk-core.mdx
+++ b/changelog/blnk-core.mdx
@@ -5,6 +5,13 @@ description: "Latest features, releases, and improvements."
 "og:description": "Explore the Blnk Core changelog. Track our releases, fixes, enhancements, and version history for Blnk's core platform"
 ---
 
+<Update label="0.13.4" description="Mar 6, 2026">
+  ## Fixes & improvements
+
+  - Reconciliation improvements and bug fixes.
+  - Introduced logical operators to direct DB filters.
+</Update>
+
 <Update label="0.13.3" description="Feb 24, 2026">
   ## Fixes & improvements
 

--- a/search/db/filtering.mdx
+++ b/search/db/filtering.mdx
@@ -38,6 +38,7 @@ curl -X POST "https://YOUR_BLNK_INSTANCE_URL/transactions/filter" \
   -H "X-Blnk-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
+    "logical_operator": "or",
     "filters": [
       { "field": "status", "operator": "eq", "value": "APPLIED" },
       { "field": "currency", "operator": "in", "values": ["USD", "EUR"] }
@@ -58,6 +59,7 @@ curl -X POST "https://YOUR_BLNK_INSTANCE_URL/transactions/filter" \
 | `include_count` | boolean | No | Include total count in response (default: `false`) |
 | `limit` | integer | No | Max records to return (default: `20`, max: `100`) |
 | `offset` | integer | No | Records to skip (default: `0`) |
+| `logical_operator` | string | No | Combine filters with `"and"` (default) or `"or"` |
 
 ---
 
@@ -141,6 +143,8 @@ For `like` and `ilike` operators, use `%` as a wildcard. `%savings%` matches any
 </Tip>
 
 ---
+
+
 
 ## Sorting
 


### PR DESCRIPTION
## Summary
Documentation updates for Blnk Core v0.13.4.

## Changes
- **Changelog**: Add v0.13.4 entry with reconciliation improvements and logical operators for direct DB filters
- **Search via Database Filtering** (`search/db/filtering.mdx`): Document `logical_operator` parameter — add to Request format example and parameter table; supports `"and"` (default) or `"or"` to combine filters