### PR TITLE
feat: Add Blnk Watch documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ledger/*/*/query-parameters-archive.mdx
 .vscode
 untracked/
 blnk/
+blnk-watch/
 
 # Cursor rules and documentation files
 .cursor/

--- a/docs.json
+++ b/docs.json
@@ -172,10 +172,29 @@
         "hidden": true,
         "groups": [
           {
-            "group": "Overview",
+            "group": "Guides",
             "icon": "book-open",
             "pages": [
-              "watch/overview"
+              "watch/quick-start",
+              "watch/mental-model",
+              "watch/core-integration",
+              "watch/commands",
+              "watch/configuration"
+            ]
+          },
+          {
+            "group": "Watch DSL",
+            "icon": "file-code",
+            "pages": [
+              "watch/rules/introduction"
+            ]
+          },
+          {
+            "group": "Watch API",
+            "icon": "code",
+            "pages": [
+              "watch/api/inject-transaction",
+              "watch/api/get-verdict"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -178,6 +178,7 @@
               "watch/quick-start",
               "watch/mental-model",
               "watch/core-integration",
+              "watch/webhooks",
               "watch/commands",
               "watch/configuration"
             ]

--- a/docs.json
+++ b/docs.json
@@ -167,6 +167,20 @@
         ]
       },
       {
+        "tab": "Watch",
+        "icon": "search-code",
+        "hidden": true,
+        "groups": [
+          {
+            "group": "Overview",
+            "icon": "book-open",
+            "pages": [
+              "watch/overview"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Use Cases",
         "icon": "graduation-cap",
         "groups": [

--- a/watch/api/get-verdict.mdx
+++ b/watch/api/get-verdict.mdx
@@ -1,0 +1,59 @@
+---
+sidebarTitle: "Get verdict"
+title: "Get transaction verdict"
+description: "Retrieve the Watch evaluation result for a transaction: final verdict, risk score, and reason."
+api: "GET http://localhost:8081/transactions/{transaction_id}"
+noindex: true
+"og:title": "Get Transaction Verdict • Watch API Reference"
+---
+
+import NeedHelp from "/snippets/need-help.mdx";
+
+Use this to check if/how a transaction was classified and why.
+
+It returns the Watch evaluation result for a transaction—the consolidated verdict, risk score, and reason produced after rules are evaluated. 
+
+### Path
+
+<ParamField path="transaction_id" type="string" required>
+  The transaction ID to retrieve the verdict for.
+</ParamField>
+
+<RequestExample>
+```bash
+curl http://localhost:8081/transactions/txn_123
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "transaction_id": "txn_123",
+  "amount": 1000.00,
+  "currency": "USD",
+  "source": "balance_123",
+  "destination": "balance_456",
+  "reference": "ref_001",
+  "description": "Payment",
+  "status": "applied",
+  "created_at": "2024-01-15T10:30:00Z",
+  "meta_data": {
+    "key": "value"
+  }
+}
+```
+
+```json 404
+{
+  "error": "Transaction not found"
+}
+```
+
+```json 500
+{
+  "error": "Failed to retrieve transaction"
+}
+```
+</ResponseExample>
+
+<NeedHelp />

--- a/watch/api/inject-transaction.mdx
+++ b/watch/api/inject-transaction.mdx
@@ -1,0 +1,74 @@
+---
+sidebarTitle: "Inject transaction"
+title: "Inject Transaction"
+description: "Inject a transaction into the watch system for real-time risk evaluation."
+api: "POST http://localhost:8081/inject"
+noindex: true
+"og:title": "Inject Transaction • Watch API Reference"
+---
+
+import NeedHelp from "/snippets/need-help.mdx";
+
+When using Watch, use this endpoint to inject a transaction into the service for real-time risk evaluation.
+
+<Note>Any extra Blnk attributes you want rules to use should be sent inside `meta_data`.</Note>
+
+<Info>The field names match Blnk transaction naming — `transaction_id`, `amount`, `currency`, `source`, `destination`, `created_at`, `meta_data` — so mapping from Blnk Core stays predictable. </Info>
+
+### Body
+
+<ParamField body="amount" type="number">
+  The transaction amount to evaluate.
+</ParamField>
+<ParamField body="currency" type="string">
+  The three-letter ISO currency code. For example, `USD`.
+</ParamField>
+<ParamField body="transaction_id" type="string">
+  A unique identifier for the transaction. If not provided, Watch generates a UUID.
+</ParamField>
+<ParamField body="source" type="string">
+  The source balance identifier.
+</ParamField>
+<ParamField body="destination" type="string">
+  The destination balance identifier.
+</ParamField>
+<ParamField body="description" type="string">
+  A free-form description of the transaction.
+</ParamField>
+<ParamField body="created_at" type="string">
+  The transaction timestamp in ISO 8601 format. If not provided, Watch uses the current server time.
+</ParamField>
+<ParamField body="meta_data" type="object">
+  Additional metadata as key-value pairs. Use this to pass Blnk attributes needed by your rules.
+</ParamField>
+
+<RequestExample>
+```bash
+curl -X POST http://localhost:8081/inject \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 5000.00,
+    "currency": "USD",
+    "transaction_id": "txn_ref_001",
+    "source": "balance_123",
+    "destination": "balance_456",
+    "description": "High-value transfer",
+    "created_at": "2026-03-16T09:00:00Z",
+    "meta_data": {
+      "merchant_category": "finance",
+      "country": "US"
+    }
+  }'
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "transaction_id": "0f81a4e1-2b8d-496b-8d5d-a4e1e980f1a6",
+  "message": "Call GET /transactions/{id} to fetch the processed transaction or set ALERT_WEBHOOK_URL to get webhooks when a rule triggers for the transaction."
+}
+```
+</ResponseExample>
+
+<NeedHelp />

--- a/watch/commands.mdx
+++ b/watch/commands.mdx
@@ -4,10 +4,214 @@ title: "Commands"
 description: "Reference for Blnk Watch CLI commands and options."
 ---
 
-## Overview
+Blnk Watch exposes a small set of CLI commands for running the service and syncing transactions from Blnk Core.
 
-Content coming soon.
+<Info>
+The `make` targets run the default command shape only. 
 
-## Command reference
+If you need to change flags such as `-port`, `-sync-interval`, or `-batch-size`, use the `blnk-watch` binary directly.
+</Info>
 
-Placeholder for commands reference.
+---
+
+## start
+
+Use `start` to run Watch in continuous mode. It starts the Watch HTTP service and, when `DB_URL` is set, starts the watermark syncer in the same process.
+
+This is the simplest way to run Watch against Blnk Core in one process. New transactions are continuously pulled from Blnk Core on a schedule, written into Watch, and evaluated against your active rules as they flow in.
+
+Use `start` when you want the API and automatic Core ingestion together. If you only need the API (e.g. you send transactions via the inject API), use `watch`. If you only need to sync from Core without the API, use `sync` or `sync-once`.
+
+<Tabs>
+<Tab title="Using make">
+Runs the default command only. 
+```bash wrap
+make start
+```
+</Tab>
+<Tab title="Using Go binary">
+Use the binary to run with custom flags (port, sync interval, batch size).
+```bash wrap
+# Default: API on 8081, sync every 10s, batch size 1000
+./blnk-watch -command=start
+
+# Custom port, sync interval, and batch size
+./blnk-watch -command=start -port=9090 -sync-interval=5s -batch-size=500
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-port` | Port used by the Watch HTTP service | `8081` |
+| `-sync-interval` | How often Watch pulls new transactions from Core | `10s` |
+| `-batch-size` | Number of transactions to process per sync batch | `1000` |
+</Tab>
+</Tabs>
+
+---
+
+## install
+
+Use `install` to build and install the `blnk-watch` binary in your system.
+
+This is useful when you want to run `blnk-watch` directly from your shell instead of invoking it from the project directory.
+
+<Tabs>
+<Tab title="Using make">
+Builds the binary and installs it into `$(go env GOPATH)/bin`.
+```bash wrap
+make install
+```
+</Tab>
+<Tab title="Using Go binary">
+From the blnk-watch project root, build and install the binary into your Go path:
+```bash wrap
+go install ./cmd/blnk-watch
+```
+</Tab>
+</Tabs>
+
+> To make sure you can run `blnk-watch`, add the Go bin directory to your `PATH`. Follow the steps below for your OS:
+ 
+<Accordion title="Add Go bin to PATH" icon="terminal">
+<Tabs>
+<Tab title="macOS / Linux">
+Add to PATH for the current session:
+```bash wrap
+export PATH="$(go env GOPATH)/bin:$PATH"
+
+# Make it permanent and reload the shell (e.g. `~/.zshrc` or `~/.bashrc`)
+source ~/.zshrc
+```
+Confirm the binary is available:
+```bash wrap
+blnk-watch -command=start
+```
+</Tab>
+<Tab title="Windows">
+Add to PATH for the current session (PowerShell):
+```powershell wrap
+$env:Path += ";$(go env GOPATH)\bin"
+```
+
+To make it permanent:
+
+1. Press **Win + R**, type `sysdm.cpl`, press Enter to open System Properties.
+2. Open the **Advanced** tab → **Environment Variables**.
+3. Under **User variables**, select **Path** → **Edit**.
+4. Click **New**, then add `%USERPROFILE%\go\bin`
+5. Click **OK** on each dialog to save.
+6. Close and reopen your terminal so the updated PATH is loaded.
+
+Confirm the binary is available:
+```powershell wrap
+blnk-watch -command=start
+```
+</Tab>
+</Tabs>
+</Accordion>
+
+---
+
+## watch
+
+Use `watch` to run only the Watch service. This starts the HTTP API used to inject transactions, retrieve evaluation results, and serve the endpoints used during transaction evaluation.
+
+Use `watch` when you only need the HTTP API (e.g. you inject transactions) and do not need to pull from Blnk Core. To run both the API and Core ingestion, use `start` instead.
+
+<Tabs>
+<Tab title="Using make">
+Starts the default service command only. Use the binary if you need custom flags.
+```bash wrap
+make watch
+```
+</Tab>
+<Tab title="Using Go binary">
+Use the binary to run with a custom port or other flags.
+```bash wrap
+# Default: API on port 8081
+./blnk-watch -command=watch
+
+# Custom port
+./blnk-watch -command=watch -port=9090
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-port` | Port used by the Watch HTTP service | `8081` |
+</Tab>
+</Tabs>
+
+---
+
+## sync
+
+<Info>
+`sync` requires `DB_URL` so Watch can connect to the Blnk Core database.
+</Info>
+
+Use `sync` to run the watermark sync service continuously. This command reads transactions from Blnk Core in batches, stores them in Watch, and keeps moving forward from the current watermark.
+
+In practice, `sync` is useful for backfills, historical evaluation, or when you only need to pull transactions from Core (no HTTP API). On a fresh setup, it can process older transactions from the configured sync start point. After that, it continues syncing new transactions as they appear.
+
+`sync` does not start the Watch HTTP server. To run both the API and sync from Core, use `start` instead—you cannot run `watch` and `sync` as separate services.
+
+<Tabs>
+<Tab title="Using make">
+Runs the default continuous sync command only. Use the binary to change sync settings.
+```bash wrap
+make sync
+```
+</Tab>
+<Tab title="Using Go binary">
+Use the binary to run with a custom sync interval or batch size.
+```bash wrap
+# Default: sync every 10s, batch size 1000
+./blnk-watch -command=sync
+
+# Custom sync interval and batch size
+./blnk-watch -command=sync -sync-interval=5s -batch-size=500
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-sync-interval` | How often Watch runs the next watermark sync cycle | `10s` |
+| `-batch-size` | Number of transactions to process per sync batch | `1000` |
+</Tab>
+</Tabs>
+
+---
+
+## sync-once
+
+<Info>
+`sync-once` requires `DB_URL` so Watch can connect to the Blnk Core database.
+</Info>
+
+Use `sync-once` to run a single watermark synchronization pass and then exit. It processes available historical transactions from Blnk Core up to the current watermark and stops when that run completes.
+
+This is useful for backfills, one-off reprocessing, CI or maintenance jobs, and scheduled tasks such as cron jobs where you do not want a long-running process.
+
+Unlike `sync`, this command does not keep polling for new transactions.
+
+<Tabs>
+<Tab title="Using make">
+Runs the default one-time sync only. Use the binary if you need to change the batch size.
+```bash wrap
+make sync-once
+```
+</Tab>
+<Tab title="Using Go binary">
+Use the binary to run with a custom batch size.
+```bash wrap
+# Default: batch size 1000
+./blnk-watch -command=sync-once
+
+# Custom batch size
+./blnk-watch -command=sync-once -batch-size=2000
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-batch-size` | Number of transactions to process in the one-time sync batch loop | `1000` |
+</Tab>
+</Tabs>

--- a/watch/commands.mdx
+++ b/watch/commands.mdx
@@ -1,0 +1,13 @@
+---
+sidebarTitle: "Commands"
+title: "Commands"
+description: "Reference for Blnk Watch CLI commands and options."
+---
+
+## Overview
+
+Content coming soon.
+
+## Command reference
+
+Placeholder for commands reference.

--- a/watch/commands.mdx
+++ b/watch/commands.mdx
@@ -2,6 +2,7 @@
 sidebarTitle: "Commands"
 title: "Commands"
 description: "Reference for Blnk Watch CLI commands and options."
+noindex: true
 ---
 
 Blnk Watch exposes a small set of CLI commands for running the service and syncing transactions from Blnk Core.

--- a/watch/configuration.mdx
+++ b/watch/configuration.mdx
@@ -1,0 +1,9 @@
+---
+sidebarTitle: "Configuration file"
+title: "Configuration"
+description: "Configure Watch."
+---
+
+## Overview
+
+Configure Watch. Content coming soon.

--- a/watch/configuration.mdx
+++ b/watch/configuration.mdx
@@ -2,6 +2,7 @@
 sidebarTitle: "Configuration file"
 title: "Configuration"
 description: "Configure Blnk Watch with environment variables."
+noindex: true
 ---
 
 ## Overview

--- a/watch/configuration.mdx
+++ b/watch/configuration.mdx
@@ -1,9 +1,114 @@
 ---
 sidebarTitle: "Configuration file"
 title: "Configuration"
-description: "Configure Watch."
+description: "Configure Blnk Watch with environment variables."
 ---
 
 ## Overview
 
-Configure Watch. Content coming soon.
+Blnk Watch is configured with environment variables, usually through a `.env` file.
+
+The minimum configuration depends on how you run Watch:
+
+- If you run `watch` only and inject transactions through the API, configure where Watch should load rules from.
+- If you run `start`, `sync`, or `sync-once`, add `DB_URL` so Watch can read transactions from Blnk Core.
+
+Watch loads `.env` by default. 
+
+```bash Default .env
+# Default rules directory in your project root
+WATCH_SCRIPT_DIR=watch_scripts
+
+# If using start, sync, or sync-once
+DB_URL=postgres://user:password@localhost:5432/blnk?sslmode=disable
+```
+
+---
+
+## Core connection configuration
+
+Use these settings when Watch needs to read transactions from Blnk Core. This is required for `start`, `sync`, and `sync-once`. It is not required if you run `watch` in API-only mode and inject transactions manually.
+
+```bash .env
+DB_URL=postgres://user:password@localhost:5432/blnk?sslmode=disable
+```
+
+| Variable | Description | Default | Required |
+| --- | --- | --- | --- |
+| `DB_URL` | PostgreSQL connection string for the Blnk Core database. Watch uses this for watermark sync and historical transaction processing. | None | Conditional |
+
+---
+
+## Rule source configuration
+
+These settings control where Watch loads rules from. You can load rules from a local directory or point Watch at a Git repository that contains `.ws` rule files.
+
+If you set `WATCH_SCRIPT_GIT_REPO`, Watch clones the repository into `WATCH_SCRIPT_DIR`, processes the rules there, and keeps that local copy in sync.
+
+```bash .env
+# Local directory only (default)
+WATCH_SCRIPT_DIR=watch_scripts
+
+# With Git-based rule loading
+WATCH_SCRIPT_GIT_REPO=https://github.com/your-org/watch-rules.git
+WATCH_SCRIPT_GIT_BRANCH=main
+```
+
+| Variable | Description | Default | Required |
+| --- | --- | --- | --- |
+| `WATCH_SCRIPT_DIR` | Local directory Watch reads for `.ws` rule files. This is also the destination directory when Git-based rule loading is enabled. | `watch_scripts` | No |
+| `WATCH_SCRIPT_GIT_REPO` | Git repository URL containing Watch rules. When set, Watch pulls rules from this repository instead of relying only on local files. | None | No |
+| `WATCH_SCRIPT_GIT_BRANCH` | Git branch Watch should track when `WATCH_SCRIPT_GIT_REPO` is set. | `main` | No |
+
+<Note>
+Git-based rule loading requires `git` to be installed on the machine running Watch. For private repositories, Git authentication (e.g. SSH keys, credential helper, or personal access token) must be set up on that machine so Watch can clone and pull the repo.
+</Note>
+
+---
+
+## Core sync configuration
+
+These settings apply when Watch **syncs** transaction data from Blnk Core (e.g. with `start`, `sync`, or `sync-once`). They control where the initial sync starts when there is no saved sync progress yet. They do not control rule evaluation.
+
+Use `SYNC_TRANSACTION_LOOKBACK` when you want Watch to start from a relative window (e.g. the last 48 hours). Use `SYNC_TRANSACTION_START_TIME` when you want a fixed start time. If both are set, `SYNC_TRANSACTION_START_TIME` takes precedence.
+
+{/* Sync interval and batch size are runtime settings too, but they are configured with CLI flags such as `-sync-interval` and `-batch-size`, not environment variables. See [Commands](/watch/commands) for those options. */}
+
+```bash .env
+# Relative lookback (e.g. last 48 hours)
+SYNC_TRANSACTION_LOOKBACK=48h
+
+# Or fixed start time (overrides lookback when set)
+SYNC_TRANSACTION_START_TIME=2026-03-11T00:00:00Z
+```
+
+| Variable | Description | Default | Required |
+| --- | --- | --- | --- |
+| `SYNC_TRANSACTION_LOOKBACK` | How far back to sync when starting (e.g. `48h`, `168h`). Go duration format. | `48h` | No |
+| `SYNC_TRANSACTION_START_TIME` | Absolute starting point for the initial sync. Accepted formats are `2026-03-11T00:00:00Z`, `2026-03-11 15:04:05`, or `2026-03-11`. | None | No |
+
+---
+
+## Alert webhook configuration
+
+These settings control alert webhook delivery when one or more rules are triggered by a transaction within Watch.
+
+Watch can send alerts to a primary webhook and fall back to secondary or backup endpoints if needed.
+
+```bash .env
+ALERT_WEBHOOK_URL=https://your-server.com/alerts
+ALERT_WEBHOOK_SECONDARY_URL=https://your-server.com/alerts-secondary
+ALERT_WEBHOOK_BACKUP_URL=https://your-server.com/alerts-backup
+ALERT_WEBHOOK_API_KEY=your_api_key_here
+ALERT_WEBHOOK_RISK_THRESHOLD=0.5
+ALERT_WEBHOOK_ENABLED=true
+```
+
+| Variable | Description | Default | Required |
+| --- | --- | --- | --- |
+| `ALERT_WEBHOOK_URL` | Primary alert webhook URL. | None | No |
+| `ALERT_WEBHOOK_SECONDARY_URL` | Secondary fallback alert webhook URL. Watch uses it if the primary webhook fails. | None | No |
+| `ALERT_WEBHOOK_BACKUP_URL` | Final fallback alert webhook URL. Watch uses it if earlier webhook attempts fail. | None | No |
+| `ALERT_WEBHOOK_API_KEY` | Bearer token sent in the `Authorization` header for alert webhook requests. | None | No |
+| `ALERT_WEBHOOK_RISK_THRESHOLD` | Minimum risk score that should trigger an alert. | `0.5` | No |
+| `ALERT_WEBHOOK_ENABLED` | Enables or disables alert webhook delivery. Set it to `false` to disable. | `true` | No |

--- a/watch/core-integration.mdx
+++ b/watch/core-integration.mdx
@@ -1,13 +1,107 @@
 ---
 sidebarTitle: "Core integration"
 title: "Core Integration"
-description: "Integrate Blnk Watch with Blnk Core and your transaction flow."
+description: "Connect Blnk Watch to Blnk Core so your ledger transactions start being evaluated against your rules."
 ---
 
-## Overview
+Watch becomes useful once it is connected to your Blnk Core instance. 
 
-Content coming soon.
+Connecting Watch allows transactions created in Core to be evaluated automatically against those rules as part of your transaction flow.
 
-## Integration patterns
+<Info>
+We recommend having at least one rule set up before you connect your live Blnk Core to Watch. Without rules, every transaction is evaluated as a non-match.
+</Info>
 
-Placeholder for core integration content.
+There are two ways to integrate Watch with Core:
+
+1. Sync directly from the Core database (recommended)
+2. Push transactions into Watch through the API
+
+In most setups, the recommended approach is to simply let Watch read transactions directly from the Core database as they are created.
+
+---
+
+## Sync from the Core database
+
+<Info>Ensure that `DB_URL` is set in your `.env` file.</Info>
+
+Watch connects directly to the Blnk Core database and continuously evaluates transactions as they appear. To run this, use the `start` command.
+
+```bash
+blnk-watch -command=start
+```
+
+When Watch starts, it first synchronizes historical transactions. After that initial sync, Watch keeps reading new transactions from the database. Each transaction is picked up and evaluated against your configured rules automatically.
+
+This is the simplest way to connect Watch to Core because you do not need to register webhooks or manually send transactions into Watch.
+
+In practice, the main thing you usually need to handle is what happens after evaluation. Most teams do that by consuming Watch results through [alert webhooks](/watch/webhooks).
+
+> **Use this approach when:**
+>
+>- Watch should stay aligned with the transactions already written by Blnk Core.
+>- You want historical transactions evaluated on startup before live processing continues.
+>- You want the least operational overhead between Core and Watch.
+>- You do not want to build or maintain a separate ingestion pipeline.
+
+---
+
+## Push transactions into Watch through the API
+
+Watch can also run as a pure evaluation service.
+
+In this mode, Watch exposes HTTP endpoints and expects transactions to be sent to it. Core does not get read directly from the database. Instead, something forwards transactions into Watch as they happen.
+
+You have two ways to push transactions via the API:
+
+<Tabs>
+<Tab title="Via inbound webhooks">
+Blnk Core can send transaction events directly to Watch through the `/webhook` endpoint.
+
+<Steps>
+<Step title="Run the Watch service">
+Start the Watch service 
+```bash
+blnk-watch -command=watch
+```
+</Step>
+<Step title="Register the webhook in Core">
+Register the hook in Core using the [hooks endpoint](/hooks/overview) — you can use a PRE or POST hook. 
+
+Point the hook URL to Watch's `/blnkwebhook` endpoint:
+
+```bash wrap
+curl -X POST "http://YOUR_BLNK_CORE_URL/hooks" \
+  -H "X-Blnk-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Watch risk evaluation",
+    "url": "http://localhost:8081/blnkwebhook",
+    "type": "POST_TRANSACTION",
+    "active": true,
+    "timeout": 30,
+    "retry_count": 3
+  }'
+```
+
+Replace `http://localhost:8081` with your Watch base URL if it runs elsewhere.
+</Step>
+<Step title="Receive and evaluate transactions">
+Once registered, every time new transactions are created, Blnk fires a webhook to Watch. Watch receives it and injects the transaction for evaluation.
+</Step>
+</Steps>
+
+This approach is useful when you want event-driven delivery into Watch without giving Watch direct database access.
+</Tab>
+<Tab title="Manual ingestion">
+You can also submit transactions directly to the Watch API using the [`/inject` endpoint](/watch/api/inject-transaction).
+
+This is useful when you want to:
+
+- test rules quickly
+- build a custom ingestion pipeline
+- send transactions from non-Core systems
+
+This gives you the most control over how transactions reach Watch, but it also means your system is responsible for sending them.
+</Tab>
+</Tabs>

--- a/watch/core-integration.mdx
+++ b/watch/core-integration.mdx
@@ -1,0 +1,13 @@
+---
+sidebarTitle: "Core integration"
+title: "Core Integration"
+description: "Integrate Blnk Watch with Blnk Core and your transaction flow."
+---
+
+## Overview
+
+Content coming soon.
+
+## Integration patterns
+
+Placeholder for core integration content.

--- a/watch/core-integration.mdx
+++ b/watch/core-integration.mdx
@@ -2,6 +2,7 @@
 sidebarTitle: "Core integration"
 title: "Core Integration"
 description: "Connect Blnk Watch to Blnk Core so your ledger transactions start being evaluated against your rules."
+noindex: true
 ---
 
 Watch becomes useful once it is connected to your Blnk Core instance. 

--- a/watch/mental-model.mdx
+++ b/watch/mental-model.mdx
@@ -1,0 +1,107 @@
+---
+sidebarTitle: "How Watch works"
+title: "How Blnk Watch works"
+description: "Understand the mental model behind Blnk Watch: how transactions enter Watch, how rules are evaluated, and how a final risk verdict is produced."
+---
+
+## Overview
+
+Every transaction in your system carries signals that indicate risk. A payment might exceed a limit, a payout might violate a policy, or a pattern of activity might suggest abuse.
+
+Blnk Watch [evaluates those signals](#evaluation-workflow) using [rules you define](#rule-evaluation) and returns a [risk verdict](#final-verdict) for each transaction. It runs alongside your Blnk Ledger and allows you to apply checks before, during, or after a transaction is processed.
+
+When a transaction occurs, Watch evaluates it against your rules and produces a verdict such as `allow`, `review`, `block`, etc.
+
+With Watch, it becomes easier to enforce controls like:
+
+1. Fraud and compliance checks  
+2. Transaction limits  
+3. Velocity monitoring  
+4. Payout or withdrawal checks  
+5. Promo abuse prevention  
+6. Operational guardrails
+
+---
+
+## Evaluation workflow
+
+```mermaid
+flowchart LR
+    A[Blnk Core webhook]
+    B["start (continuous mode)"]
+    C["sync (historical mode)"]
+    D["API inject (manual)"]
+
+    A --> E[Watch evaluation pipeline]
+    B --> E
+    C --> E
+    D --> E
+
+    E --> F[Rules evaluated]
+    F --> G[Risk scores produced]
+    G --> H[Final verdict]
+```
+
+Once a transaction enters Watch, it follows the same lifecycle every time:
+
+1. It checks the transaction against the active rules.  
+2. Multiple rules can trigger for the same transaction.
+3. Each triggered rule contributes a score and a reason.
+4. Watch consolidates all triggered rules into a single final decision.
+
+The result is a consistent risk assessment that your system can use to determine what should happen next.
+
+---
+
+## Rule evaluation
+
+Rules define the decision logic used by Watch. They determine how transactions are evaluated and ultimately classified.
+
+You define and manage these rules using the [Watch DSL](/watch/rules). Every rule contains two main parts:
+
+1. A `when` condition that describes the pattern Watch should look for in a transaction.
+2. A `then` action that defines the outcome when the condition triggers, including the verdict, score, and reason.
+
+```text wrap
+rule <RuleName> {
+
+  when <condition>                
+
+  then <verdict>                 
+       score   <value>
+       reason  "<explanation>"
+}
+```
+
+During evaluation, Watch runs every transaction through the active rule set and records only the rules that trigger.
+
+The evaluation process follows a few simple principles:
+
+1. If a rule does not trigger for the transaction, it contributes nothing to the evaluation.
+2. If a rule triggers, it produces a risk signal consisting of a verdict, score, and reason.
+3. Multiple rules can trigger for the same transaction during a single evaluation cycle.
+4. All triggered signals are preserved and later consolidated into the final decision.
+
+Because of this evaluation model, rule design works best when rules are **small and focused**. Each rule should capture a single risk pattern or control. 
+
+Watch then combines the signals from multiple rules to form a broader transaction-level assessment.
+
+---
+
+## Final verdict
+
+After collecting all rule outcomes, Watch produces one consolidated result for the transaction. This consolidation step turns many rule-level outcomes into one application-ready decision:
+
+1. `final_risk_score` summarizes the combined risk signals.
+2. `final_verdict` represents the action state your system should use.
+3. `final_reason` explains the main context behind that decision.
+
+Your app can then act in a deterministic way:
+
+1. Continue normal processing for `allow`.
+2. Route the transaction for additional checks for `review`.
+3. Stop or reject the transaction for `block`.
+
+<Note>
+**Keep in mind:** Watch supports more verdicts than these three. You can define custom actions in your rules to match your workflow. 
+</Note>

--- a/watch/mental-model.mdx
+++ b/watch/mental-model.mdx
@@ -2,6 +2,7 @@
 sidebarTitle: "How Watch works"
 title: "How Blnk Watch works"
 description: "Understand the mental model behind Blnk Watch: how transactions enter Watch, how rules are evaluated, and how a final risk verdict is produced."
+noindex: true
 ---
 
 ## Overview

--- a/watch/overview.mdx
+++ b/watch/overview.mdx
@@ -1,8 +1,0 @@
----
-title: "Watch Overview"
-description: "Overview of the Watch feature."
----
-
-## Overview
-
-This section covers Watch functionality. Content coming soon.

--- a/watch/overview.mdx
+++ b/watch/overview.mdx
@@ -1,0 +1,8 @@
+---
+title: "Watch Overview"
+description: "Overview of the Watch feature."
+---
+
+## Overview
+
+This section covers Watch functionality. Content coming soon.

--- a/watch/quick-start.mdx
+++ b/watch/quick-start.mdx
@@ -4,6 +4,7 @@ title: "Getting Started with Blnk Watch"
 description: "Learn how to install, configure, and run Blnk Watch to monitor transactions with custom risk rules."
 "og:title": "Getting Started with Blnk Watch"
 "og:description": "Learn how to install, configure, and run Blnk Watch to monitor transactions with custom risk rules."
+noindex: true
 ---
 
 Blnk Watch is a lightweight, rule-based transaction monitoring engine. 

--- a/watch/quick-start.mdx
+++ b/watch/quick-start.mdx
@@ -1,0 +1,143 @@
+---
+sidebarTitle: "Quick start"
+title: "Getting Started with Blnk Watch"
+description: "Learn how to install, configure, and run Blnk Watch to monitor transactions with custom risk rules."
+"og:title": "Getting Started with Blnk Watch"
+"og:description": "Learn how to install, configure, and run Blnk Watch to monitor transactions with custom risk rules."
+---
+
+Blnk Watch is a lightweight, rule-based transaction monitoring engine. 
+
+Watch evaluates transactions using rules written in a simple DSL. You send transactions to Watch, and it returns a risk verdict, so you can enforce limits, detect fraud, and stay compliant without running heavy infrastructure.
+
+In this quick start, you will:
+
+1. Start the Watch service
+2. Write a rule  
+3. Send a transaction for evaluation
+4. See the risk decision
+
+Let's dive in!
+
+---
+
+<Steps titleSize="h3">
+<Step title="Install Blnk Watch">
+
+First, download Watch from the open-source repository:
+
+```bash
+git clone https://github.com/blnkfinance/watch && cd watch
+```
+
+Next, build and run the Watch service:
+
+<CodeGroup>
+```bash macOS/Linux
+make start
+```
+
+```bash Windows
+go build -o blnk-watch ./cmd/blnk-watch
+./blnk-watch -command=start
+```
+</CodeGroup>
+
+By default Watch listens on port 8081. The service is ready when it starts listening on the port.
+</Step>
+
+<Step title="Create your first rule">
+
+Create a rules directory and add a rule file:
+
+
+```bash
+mkdir -p watch_scripts && cd watch_scripts
+touch HighValueUSD.ws
+```
+
+Add this rule to `HighValueUSD.ws`:
+
+```bash
+rule HighValueUSD {
+  description "Flag USD transactions over 4,000 for review"
+
+  when amount > 4000 and currency == "USD"
+
+  then review
+       score   0.5
+       reason  "USD transaction exceeds 4,000"
+}
+```
+
+This rule triggers for any USD transaction above $4,000.
+
+</Step>
+
+<Step title="Send a transaction">
+
+Use the [inject endpoint](/watch/api/inject-transaction) to send a transaction to Watch.
+
+```bash Request {5,6}
+curl -X POST http://localhost:8081/inject \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transaction_id": "txn_quickstart_001",
+    "amount": 5000,
+    "currency": "USD",
+    "source": "acct_sender",
+    "destination": "acct_receiver",
+    "reference": "ref_001",
+    "description": "Sample transfer"
+  }'
+```
+
+If successful (200), Watch queues the transaction for evaluation.
+
+```json Response
+{
+    "message": "Call GET /transactions/{id} to fetch the processed transaction or set ALERT_WEBHOOK_URL to get webhooks when a rule triggers for the transaction.",
+    "transaction_id": "txn_quickstart_001"
+}
+```
+</Step>
+
+<Step title="Check the result">
+
+Fetch the processed transaction:
+
+```bash
+curl http://localhost:8081/transactions/txn_quickstart_001
+```
+
+You should see a response similar to:
+
+```json Response
+{
+    "meta_data": {
+        "consolidated_risk_assessment": {
+            "final_reason": "USD transaction exceeds 4,000",
+            "final_risk_score": 0.5,
+            "final_verdict": "review",
+            "source_count": 1
+        },
+        "dsl_verdicts": [
+            {
+                "reason": "USD transaction exceeds 4,000",
+                "rule_id": 0,
+                "score": 0.5,
+                "verdict": "review"
+            }
+        ],
+        "evaluation_status": "completed",
+        "risk_evaluation_timestamp": "2026-03-15T22:12:00.99813+01:00"
+    }
+}
+```
+
+The verdict appears because the transaction amount, 5000 USD, triggered the rule. 
+
+Try sending another transaction with a smaller amount, such as 3000 USD. Because it does not meet the rule condition, the rule will not trigger. You can also experiment with different amounts or currencies to see how the rule behaves.
+
+</Step>
+</Steps>

--- a/watch/rules/introduction.mdx
+++ b/watch/rules/introduction.mdx
@@ -1,0 +1,9 @@
+---
+sidebarTitle: "Overview"
+title: "Overview"
+description: "Introduction to the Watch rules language."
+---
+
+## Overview
+
+This section covers the Watch rules language. Content coming soon.

--- a/watch/rules/introduction.mdx
+++ b/watch/rules/introduction.mdx
@@ -2,6 +2,7 @@
 sidebarTitle: "Overview"
 title: "Overview"
 description: "Introduction to the Watch rules language."
+noindex: true
 ---
 
 ## Overview

--- a/watch/webhooks.mdx
+++ b/watch/webhooks.mdx
@@ -1,0 +1,100 @@
+---
+sidebarTitle: "Webhooks"
+title: "Managing Alert Webhooks"
+description: "Configure and use alert webhooks to receive risk alerts when Watch rules are triggered."
+---
+
+Alert webhooks let you send risk alerts to your own endpoints when one or more rules trigger for a transaction. 
+
+You configure webhook URLs and options with environment variables; Watch sends a POST request with the consolidated verdict, score, and evaluation data whenever the alert criteria are met.
+
+---
+
+## How alert webhooks work
+
+Enable alert webhooks by setting the webhook URL and turning delivery on in your [`.env` file](/watch/configuration#alert-webhook-configuration):
+
+```bash .env
+# Where to send alert payloads (required for delivery)
+ALERT_WEBHOOK_URL=https://your-server.com/alerts
+
+# Set to false to disable alert delivery; default is true
+ALERT_WEBHOOK_ENABLED=true
+```
+
+Watch sends an alert webhook only when all of these conditions are met:
+
+1. **At least one rule triggered** for the transaction during evaluation.
+2. **Alert webhooks are enabled** — `ALERT_WEBHOOK_ENABLED` is not set to `false`.
+3. **Alert criteria are met** — either:
+   - The consolidated **risk score** is greater than or equal to `ALERT_WEBHOOK_RISK_THRESHOLD` (default is `0.5`), or
+   - The consolidated **verdict** is `block` or `review`.
+
+If no webhook URLs are set, Watch skips delivery and does not retry.
+
+---
+
+## Delivery behavior
+
+Watch sends a `POST` request with `Content-Type: application/json` and the [payload structure](#webhook-payload-structure) below. 
+
+If you set `ALERT_WEBHOOK_API_KEY`, Watch includes `Authorization: Bearer <value>` on each request. Your endpoint should return a 2xx status code to indicate success.
+
+---
+
+## Webhook payload structure
+
+Here's the alert payload sent when a transaction triggers one or more rules:
+
+```json wrap
+{
+  "transaction_id": "txn_abc123",
+  "description": "Transaction amount exceeds 10,000 in any currency.",
+  "risk_level": "medium",
+  "risk_score": 0.65,
+  "verdict": "review",
+  "source_count": 2,
+  "evaluation_data": {
+    "final_risk_score": 0.65,
+    "final_verdict": "review",
+    "final_reason": "Transaction amount exceeds 10,000 in any currency.",
+    "source_count": 2,
+    "transaction_amount": 15000,
+    "transaction_reference": "ref_001",
+    "dsl_verdicts": [
+      { "rule": "HighValueCheck", "verdict": "review", "reason": "Amount > 10000" },
+      { "rule": "VelocityCheck", "verdict": "allow", "reason": "" }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `transaction_id` | string | ID of the transaction that was evaluated. |
+| `description` | string | Human-readable summary; usually the consolidated reason. |
+| `risk_level` | string | One of `very_low`, `low`, `medium`, `high` (derived from risk score). |
+| `risk_score` | number | Consolidated risk score (0–1). |
+| `verdict` | string | Consolidated verdict (e.g. `allow`, `review`, `block`). |
+| `source_count` | integer | Number of rules that triggered for this transaction. |
+| `evaluation_data` | object | Detailed evaluation output (see below). |
+
+The `evaluation_data` object contains:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `final_risk_score` | number | Same as top-level `risk_score`. |
+| `final_verdict` | string | Same as top-level `verdict`. |
+| `final_reason` | string | Same as top-level `description`. |
+| `source_count` | integer | Same as top-level `source_count`. |
+| `transaction_amount` | number | Transaction amount. |
+| `transaction_reference` | string | Transaction reference, if set. |
+| `dsl_verdicts` | array | Per-rule verdicts and reasons when available. |
+
+---
+
+## Security considerations
+
+- Use HTTPS for all webhook URLs in production.
+- Set `ALERT_WEBHOOK_API_KEY` and validate the `Authorization: Bearer <token>` header in your endpoint to ensure requests are from Watch.
+- Do not log or store the API key in plain text.

--- a/watch/webhooks.mdx
+++ b/watch/webhooks.mdx
@@ -2,6 +2,7 @@
 sidebarTitle: "Webhooks"
 title: "Managing Alert Webhooks"
 description: "Configure and use alert webhooks to receive risk alerts when Watch rules are triggered."
+noindex: true
 ---
 
 Alert webhooks let you send risk alerts to your own endpoints when one or more rules trigger for a transaction. 


### PR DESCRIPTION
## Summary

This PR adds documentation for **Blnk Watch**, a rule-based transaction monitoring engine. The docs live under a new **Watch** tab in the Mintlify navigation. The tab is currently **hidden** (`hidden: true` in `docs.json`) so it can be enabled when ready.

## What's included

### Navigation

- New **Watch** tab (icon: `search-code`) with three groups:
  - **Guides** – quick start, mental model, core integration, webhooks, commands, configuration
  - **Watch DSL** – rules introduction (WIP)
  - **Watch API** – inject transaction, get verdict

### New pages

| Page | Description |
|------|-------------|
| **Quick start** | Install, configure, and run Watch; write a rule; send a transaction and get a risk verdict |
| **Mental model** | How Watch works: transaction flow, rule evaluation, and final verdict |
| **Core integration** | Integrating Watch with Blnk Ledger (before/during/after transaction processing) |
| **Webhooks** | Configuring alert webhooks to receive risk alerts when rules trigger |
| **Commands** | CLI commands for running and managing Watch |
| **Configuration** | Environment variables and config options (including alert webhook settings) |
| **Rules (introduction)** | Introduction to the Watch DSL and rules |
| **API: Inject transaction** | API for sending transactions to Watch for evaluation |
| **API: Get verdict** | API for retrieving the risk verdict for a transaction |

### Other changes

- **`.gitignore`** – one new entry (likely Mintlify/build related).

## Files changed

- `docs.json` – Watch tab and navigation (~34 lines added)
- `watch/quick-start.mdx` – 143 lines
- `watch/mental-model.mdx` – 107 lines
- `watch/core-integration.mdx` – 107 lines
- `watch/webhooks.mdx` – 100 lines
- `watch/commands.mdx` – 217 lines
- `watch/configuration.mdx` – 114 lines
- `watch/rules/introduction.mdx` – 9 lines
- `watch/api/inject-transaction.mdx` – 74 lines
- `watch/api/get-verdict.mdx` – 59 lines
- `.gitignore` – 1 line

**Total:** 11 files changed, 965 insertions.

## Commits

1. **feat: add Watch tab with overview page (hidden)** – Add Watch tab to nav (hidden)
2. **docs(watch): add Watch docs, mental model, API reference, and quick start** – Core Watch docs and API reference
3. **Add Watch webhooks doc and update Watch docs** – Webhooks page and doc updates

## How to enable the Watch tab

When ready to show Watch in the docs, set `"hidden": false` (or remove the `hidden` key) for the Watch tab in `docs.json` (around line 172).
