### PR TITLE
Fix formatting of destination field in internal-balances

### DIFF
--- a/balances/internal-balances.mdx
+++ b/balances/internal-balances.mdx
@@ -64,7 +64,7 @@ curl -X POST "http://localhost:5001/transactions" \
     "currency": "USD",
     "precision": 100,
     "source": "bal_91283-8102dj1-1209212-129109",
-    "destination": "@Revenue"
+    "destination": "@Revenue",
     "description": "Fund with starting balance amount",
   }'
 ```


### PR DESCRIPTION
The curl command was broken because of a missing comma after "@Revenue" This just adds the missing comma at the specific "destination" part in the json request.