### PR TITLE
Add commercial CTA cards to high-traffic docs for docs-led GTM

### DIFF
--- a/balances/introduction.mdx
+++ b/balances/introduction.mdx
@@ -7,6 +7,7 @@ description: "Learn how balances work in Blnk"
 ---
 
 import NeedHelp from "/snippets/need-help.mdx";
+import CtaDeployCloud from "/snippets/cta-deploy-cloud.mdx";
 
 Ledger balances (or balances, for short) are used to represent store of value in your Blnk Ledger, i.e., accounts, wallets, card balance, etc. They also represent the source or destination of a transaction record.
 
@@ -22,6 +23,8 @@ All ledger balances in the Blnk Ledger each have 6 main balance attributes:
 | `inflight_debit_balance` | The total sum of all amounts waiting to be deducted from a ledger balance |
 
 <Warning>**Important to note:** Balance amounts are immutable and can only be updated through transactions. You cannot manually set or alter a balance amount directly.</Warning>
+
+<CtaDeployCloud />
 
 ---
 

--- a/guides/double-entry.mdx
+++ b/guides/double-entry.mdx
@@ -8,6 +8,7 @@ description: "An engineer's guide to the Double Entry principle with Blnk."
 ---
 
 import NeedHelp from "/snippets/need-help.mdx";
+import CtaDeployCloud from "/snippets/cta-deploy-cloud.mdx";
 
 If you've read any part of the Blnk documentation, you must have heard about the Double Entry Accounting principle. 
 
@@ -50,6 +51,8 @@ The payment is entered twice (hence, "double" entry); it is removed from User A 
 
     Because the double entry aims to be the source of truth for your financial records. When you say you received \$3,000, the assumption is that someone else paid \$3,000 to you. If you received \$3,000 despite being paid \$4,000, it becomes a case of fraud and dishonesty which is terrible for any business.
 </Info>
+
+<CtaDeployCloud />
 
 ### Let's build it with Blnk
 

--- a/home/install.mdx
+++ b/home/install.mdx
@@ -8,6 +8,7 @@ description: "The developer-first toolkit for building compliant financial produ
 ---
 
 import NeedHelp from "/snippets/need-help.mdx";
+import CtaDeployCloud from "/snippets/cta-deploy-cloud.mdx";
 
 This is your guide to getting started with Blnk, pronounced as `/blank/`. If you are new to Blnk or [open-source fintech developer tools](https://blnkfinance.com), this is where you should start.
 
@@ -144,6 +145,8 @@ Your Blnk instance is now running! View the instance details to get your Core UR
 
 </Tab>
 </Tabs>
+
+<CtaDeployCloud />
 
 ---
 

--- a/ledgers/introduction.mdx
+++ b/ledgers/introduction.mdx
@@ -7,6 +7,7 @@ description: "Learn how ledgers work in Blnk"
 ---
 
 import NeedHelp from "/snippets/need-help.mdx";
+import CtaDeployCloud from "/snippets/cta-deploy-cloud.mdx";
 
 Blnk uses a structured ledger system to organize and group account balances effectively. This system simplifies navigation and improves the clarity and accessibility of financial data.
 
@@ -30,6 +31,8 @@ Blnk includes two types of ledgers — a General Ledger and custom ledgers.
     Learn how to design your ledger to organize your financial data efficiently.
   </Card>
 </CardGroup>
+
+<CtaDeployCloud />
 
 ---
 

--- a/reconciliations/overview.mdx
+++ b/reconciliations/overview.mdx
@@ -7,6 +7,7 @@ description: "Learn how to reconcile your Blnk Ledger."
 ---
 
 import NeedHelp from "/snippets/need-help.mdx";
+import CtaProSupport from "/snippets/cta-pro-support.mdx";
 
 <Info>Available in version 0.7.0 and later.</Info>
 
@@ -17,6 +18,8 @@ When performed effectively, reconciliation enhances operational efficiency, fina
 In this guide, you'll learn how to run reconciliation processes with Blnk Core.
 
 ---
+
+<CtaProSupport />
 
 ## Before you start
 

--- a/snippets/cta-deploy-cloud.mdx
+++ b/snippets/cta-deploy-cloud.mdx
@@ -1,0 +1,3 @@
+<Card title="Deploy Blnk Cloud" icon="cloud" href="https://cloud.blnkfinance.com">
+Hosted Blnk infrastructure for teams that want to deploy faster with less setup. Evaluating Blnk for production? [Talk to us](https://blnkfinance.com/contact/us).
+</Card>

--- a/snippets/cta-pro-support.mdx
+++ b/snippets/cta-pro-support.mdx
@@ -1,0 +1,3 @@
+<Card title="Need help going live?" icon="life-buoy" href="mailto:support@blnkfinance.com?subject=Interested%20in%20Pro%20Support">
+Ask about Pro Support for your deployment and operations.
+</Card>

--- a/snippets/cta-production-contact.mdx
+++ b/snippets/cta-production-contact.mdx
@@ -1,0 +1,3 @@
+<Card title="Talk to us about production use" icon="messages-square" href="https://blnkfinance.com/contact/us">
+Book a technical fit call or ask how teams run Blnk in production.
+</Card>

--- a/transactions/introduction.mdx
+++ b/transactions/introduction.mdx
@@ -8,6 +8,7 @@ description: "Learn how transactions are recorded and processed in Blnk"
 ---
 
 import NeedHelp from "/snippets/need-help.mdx";
+import CtaDeployCloud from "/snippets/cta-deploy-cloud.mdx";
 
 Transactions enable money movement between two or more balances. These can be payments, transfers, settlements, internal treasury management, etc. All transactions in Blnk are recorded with the [double entry principle](/resources/double-entry) — every transaction has a source and a corresponding destination. 
 
@@ -19,9 +20,9 @@ In this guide, you'll learn about:
 2. [Recording a transaction](#recording-a-transaction)
 3. [Verifying transactions](#verifying-transactions)
 
- 
-
 ---
+
+<CtaDeployCloud />
 
 ## Transaction properties
 

--- a/tutorials/quick-start/wallet-management.mdx
+++ b/tutorials/quick-start/wallet-management.mdx
@@ -8,6 +8,7 @@ description: "Learn how to implement a complete wallet management system with Bl
 ---
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
+import CtaProductionContact from "/snippets/cta-production-contact.mdx"
 
 ## Overview
 
@@ -70,6 +71,8 @@ Before starting, ensure you have:
 3. Optionally, you can connect your Blnk Core to your [Blnk Cloud](https://cloud.blnkfinance.com) workspace to view your ledger data.
 
 ---
+
+<CtaProductionContact />
 
 ## Create customer ledger
 


### PR DESCRIPTION
## Summary
- Add reusable Mintlify Card snippets for Cloud deploy, production contact, and Pro Support
- Place one contextual CTA on priority docs pages after high-intent milestones
- Supports docs-led GTM with clearer routing to Cloud, contact, and Pro Support

## Pages updated
- `/home/install` — after Step 1, before first transaction
- `/transactions/introduction` — after overview, before transaction properties
- `/ledgers/introduction`, `/balances/introduction`, `/guides/double-entry`
- `/tutorials/quick-start/wallet-management` — production contact after prerequisites
- `/reconciliations/overview` — Pro Support after overview