### PR TITLE
Lukas engineering task: pull-latest-from-blnkfinance-blnk-docs-t

### DIFF
--- a/advanced/backup-disk.mdx
+++ b/advanced/backup-disk.mdx
@@ -11,6 +11,8 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 Ensuring the safety and integrity of your financial data on a Blnk server is crucial. This enhanced guide covers the process of backing up your PostgreSQL database, including setup instructions, verification, storage best practices, and restoration steps.
 
+---
+
 ## Before you start
 
 Before initiating your first backup, ensure your Blnk server environment is correctly configured. This includes setting up the backup directory with appropriate permissions, ensuring your Blnk server has access to this directory, and updating the Blnk configuration file to recognize the backup directory.
@@ -21,6 +23,8 @@ Here are the prerequisites:
 - Compose 1.29.2 or later
 - Basic understanding of cron jobs (for Linux/macOS) or Task Scheduler (for Windows)
 - Familiarity with command-line interfaces and shell scripting
+
+---
 
 ## Configuring the backup directory
 
@@ -59,6 +63,8 @@ Here are the prerequisites:
   </Step>
 </Steps>
 
+---
+
 ## Automating backups
 
 Automating the backup process ensures your data is regularly backed up without manual intervention.
@@ -82,11 +88,15 @@ Automating the backup process ensures your data is regularly backed up without m
   </Step>
 </Steps>
 
+---
+
 ## Best practices for backup storage to disk
 
 - **Off-site Storage**: Regularly copy your backups to an off-site location or cloud storage to protect against local disasters.
 - **Encryption**: Encrypt your backup files to protect sensitive data from unauthorized access.
 - **Retention Policy**: Implement a retention policy to manage the lifecycle of your backups, ensuring that you keep only what's necessary and avoid unnecessary storage costs.
+
+---
 
 ## Restoring from a Backup
 

--- a/advanced/backup-s3.mdx
+++ b/advanced/backup-s3.mdx
@@ -13,6 +13,8 @@ Safeguarding your financial data on a Blnk server involves not only local backup
 
 This guide provides detailed instructions on setting up backups to Amazon S3, including configuration steps, scheduling, and verification processes.
 
+---
+
 ## Prerequisites
 
 - Docker 20.10.11 or later;
@@ -20,6 +22,8 @@ This guide provides detailed instructions on setting up backups to Amazon S3, in
 - AWS account with S3 access;
 - Basic understanding of cron jobs (for Linux/macOS) or Task Scheduler (for Windows);
 - Familiarity with command-line interfaces and shell scripting.
+
+---
 
 ## Configuring Amazon S3 Access
 
@@ -51,6 +55,8 @@ Before setting up the backup process, you need to configure your Blnk server to 
   </Step>
 </Steps>
 
+---
+
 ## Automating S3 backups
 
 After configuring access to Amazon S3, the next step is to automate the backup process.
@@ -74,11 +80,15 @@ After configuring access to Amazon S3, the next step is to automate the backup p
   </Step>
 </Steps>
 
+---
+
 ## Best practices for backup storage to Amazon S3
 
 - **Encryption**: Enable server-side encryption (SSE) for your S3 bucket to protect your backups at rest.
 - **Versioning**: Enable versioning for your S3 bucket to keep multiple versions of your backups, providing additional protection against accidental deletion or overwriting.
 - **Lifecycle policies**: Implement lifecycle policies to automatically transition older backups to more cost-effective storage classes and purge outdated backups.
+
+---
 
 ## Restoring from an S3 Backup
 

--- a/advanced/enable-https.mdx
+++ b/advanced/enable-https.mdx
@@ -19,6 +19,8 @@ This guide helps you set up HTTPs for your Blnk server. You need a basic underst
      - A valid domain name pointed to your server
 </Note>
 
+---
+
 ## Before you start
 
 Make sure that the Blnk server has been successfully deployed and is running on your machine.
@@ -65,6 +67,8 @@ Make sure that the Blnk server has been successfully deployed and is running on 
 		You should see a response indicating that the HTTPS connection is successful, along with other response headers.
 	</Step>
 </Steps>
+
+---
 
 ## Next steps
 

--- a/backup/charge-card.mdx
+++ b/backup/charge-card.mdx
@@ -8,8 +8,6 @@ description: "Learn how to implement a charge card payment system with card auth
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
-
 This tutorial provides a step-by-step guide to building a charge card payment system using Blnk Finance. 
 
 A charge card lets you buy things now and pay the full amount later in one payment. You sometimes get an available credit limit, but you must clear everything at the end of the billing cycle or you get charged fees.
@@ -642,4 +640,3 @@ You now have a fully functional charge card payment system built with Blnk Finan
 ---
 
 <RequestTutorial />
-

--- a/balances/adjusting-balances.mdx
+++ b/balances/adjusting-balances.mdx
@@ -14,6 +14,8 @@ Doing this right will ensure that your books are always balanced and correct.
 
 In this guide, you'll learn how to fix any errors or mistakes in your Blnk Ledger.
 
+---
+
 ## 1: Identify the error or omission
 
 There can be many reasons why your transaction records may not be perfectly reconciled, here are a few:
@@ -26,11 +28,15 @@ There can be many reasons why your transaction records may not be perfectly reco
     When identifying errors, it's advisable to do this with an accounting or reconciliation officer.
 </Warning>
 
+---
+
 ## 2: Find why the error occurred
 
 When you find the error, determine why it occurred. Understanding the cause will help you fix it or prevent it in the future. Usually, it'll lead you to review your [money movement map](/ledgers/money-movement-map) to ensure all amounts are moved appropriately.
 
 If the reason is unavoidable, move to the next step.
+
+---
 
 ## 3: Adjust the affected ledger balances to reflect the right records.
 

--- a/balances/balance-snapshots.mdx
+++ b/balances/balance-snapshots.mdx
@@ -15,6 +15,8 @@ Blnk Finance offers a balance snapshotting feature that enables users to access 
 
 This ensures precise financial reporting and analysis while maintaining efficient storage and retrieval systems.
 
+---
+
 ## Quick overview
 
 * **Purpose:** Records a daily snapshot of each balance to preserve historical data, enabling users to review past financial states for auditing, reporting, or analytical purposes.

--- a/changelog/v11-migration.mdx
+++ b/changelog/v11-migration.mdx
@@ -7,8 +7,6 @@ description: "Migration guide for upgrading from Blnk v0.10.x to v0.11.0, coveri
 
 import NeedHelp from "/snippets/need-help.mdx";
 
-## Overview
-
 This migration guide covers the breaking changes introduced in Blnk v0.11.0, specifically related to Typesense/Search functionality. The main change involves upgrading the Typesense server from version 0.23.x to 0.24.x, which requires updating your Docker configuration.
 
 ---

--- a/changelog/v12-migration.mdx
+++ b/changelog/v12-migration.mdx
@@ -7,8 +7,6 @@ description: "Migration guide for upgrading to Blnk v0.12.0, covering API key ha
 
 import NeedHelp from "/snippets/need-help.mdx";
 
-## Overview
-
 This migration guide covers the breaking changes introduced in Blnk v0.12.0, specifically related to API key security enhancements. The main change involves implementing SHA-256 hashing for API keys, which affects how API keys are stored and retrieved.
 
 ---
@@ -195,4 +193,3 @@ This migration guide covers the breaking changes introduced in Blnk v0.12.0, spe
 ---
 
 <NeedHelp />
-

--- a/changelog/v13-migration.mdx
+++ b/changelog/v13-migration.mdx
@@ -7,8 +7,6 @@ description: "Migration guide for upgrading to Blnk v0.13.6, covering the Update
 
 import NeedHelp from "/snippets/need-help.mdx";
 
-## Overview
-
 This migration guide covers the breaking change introduced in Blnk v0.13.6 for the [Update Metadata](/reference/update-metadata) endpoint. The response now returns the field **`meta_data`** (with underscore) instead of the inconsistent **`metadata`**. 
 
 If your code reads the update-metadata response by key, you need to handle this change.

--- a/guides/adjusting-balances.mdx
+++ b/guides/adjusting-balances.mdx
@@ -15,6 +15,8 @@ Doing this right will ensure that your books are always balanced and correct.
 
 In this guide, you'll learn how to fix any errors or mistakes in your Blnk Ledger.
 
+---
+
 ## 1: Identify the error or omission
 
 There can be many reasons why your transaction records may not be perfectly reconciled, here are a few:
@@ -27,11 +29,15 @@ There can be many reasons why your transaction records may not be perfectly reco
     When identifying errors, it's advisable to do this with an accounting or reconciliation officer.
 </Warning>
 
+---
+
 ## 2: Find why the error occurred
 
 When you find the error, determine why it occurred. Understanding the cause will help you fix it or prevent it in the future. Usually, it'll lead you to review your [money movement map](/ledgers/money-movement-map) to ensure all amounts are moved appropriately.
 
 If the reason is unavoidable, move to the next step.
+
+---
 
 ## 3: Adjust the affected ledger balances to reflect the right records.
 

--- a/guides/double-entry.mdx
+++ b/guides/double-entry.mdx
@@ -17,6 +17,8 @@ For financial applications, it means keeping the books of an organization across
 
 In this guide, we're going to learn all about the basics of bookkeeping and the Double Entry principle with Blnk. To get started, please [install Blnk on your local machine](/home/install).
 
+---
+
 ## The Double Entry Accounting principle
 
 The Double Entry Accounting principle states that for every entry into an account, there needs to be a corresponding and opposite entry into a different account.
@@ -24,6 +26,8 @@ The Double Entry Accounting principle states that for every entry into an accoun
 Only two types of entries can happen in an account — a credit and a debit. When an account is credited, money is added to the account, and when it is debited, money is removed from the account. So the principle states that if there's a credit entry in one account, there must be an equal debit entry in another account.
 
 >Another way to visualize the Double Entry principle is that for every transaction, there must be a source and a destination.
+
+---
 
 ## Part 1: The Basics
 
@@ -119,6 +123,8 @@ Let's model this on our Blnk server.
     </Step>
 </Steps>
 
+---
+
 ## Part 2: Dealing with the real world
 
 Dealing with double entry when you manage both accounts is easy. But what happens when you deal with the world? What happens if User A sends the same \$3,000 to an external bank account outside of our system? How do we represent it with the double entry principle?
@@ -131,6 +137,8 @@ To apply it, use `@World` in the source or destination field depending on what k
 | --- | --- | --- | --- | --- | --- | --- | ---
 | txn_171821872187 | ref_8728781718 | 300000 | USD | bln_ebcd230f-6265-4d4a-a4ca-45974c47f746 | @World | Invoice payment | 2024-04-23 12:32 UTC
 
+---
+
 ## Applying this to your financial application
 
 When building your financial application, it is important to apply the double entry principle to ensure that you can guard against fraud and dishonesty. Blnk allows you to be able to see both entries in one record, instead of recording the CR and DR entries in separate records in your database.
@@ -140,6 +148,8 @@ Good financial recording also saves you a lot of time and effort in performing s
 With Blnk, you don't have to worry about building the structures for Double Entry recording. You have instant access to all the tools you need to correctly record and track all transactions in your application.
 
 <NeedHelp />
+
+---
 
 ## References
 

--- a/guides/negative-balances.mdx
+++ b/guides/negative-balances.mdx
@@ -24,6 +24,8 @@ This indicator allows you to quickly assess the financial position of a ledger b
 
 In the table above, the balance for `bal_abc123` is -20000, indicating that debits exceed credits, resulting in a negative balance. On the other hand, `bal_def456` has a positive balance of 10000 because credits exceed debits.
 
+---
+
 ## How to avoid negative balances
 
 Negative balances are not a cause for alarm.

--- a/home/install.mdx
+++ b/home/install.mdx
@@ -16,6 +16,8 @@ This is your guide to getting started with Blnk, pronounced as `/blank/`. If you
 
 {/* ---
 
+---
+
 ## What is Blnk?
 
 Blnk offers an open-source financial ledger database for building and scaling fintech products. With Blnk, you can:
@@ -305,6 +307,8 @@ Now that you're set up, start with these key concepts to build your application:
 </CtaCallout>
 
 {/* ---
+
+---
 
 ## Use cases
 

--- a/hooks/examples.mdx
+++ b/hooks/examples.mdx
@@ -9,6 +9,8 @@ description: "Explore examples of how Hooks can be used in Blnk."
 
 import NeedHelp from "/snippets/need-help.mdx";
 
+---
+
 ## Fraud detection & risk assessment
 
 * **Type:** `PRE_TRANSACTION`

--- a/identities/introduction.mdx
+++ b/identities/introduction.mdx
@@ -14,6 +14,8 @@ In this guide, you'll learn how to create identities and link them to balances a
 
 <Warning>**Identities in Blnk Ledger are not a replacement for KYC verification.** While they enable you to securely store and manage customer data, you can integrate third-party tools to handle KYC verification. This ensures your compliance needs are met while maintaining a unified and organized system for managing customer information.</Warning>
 
+---
+
 ## Create an identity
 
 First step in managing and linking identities is to create one. There are two identity types in the Blnk Ledger — individual and organization.
@@ -151,6 +153,8 @@ curl -X PUT "http://localhost:5001/identities/{identity_id}" \
   }'
 ```
 
+---
+
 ## Delete an identity
 
 To delete an identity, call the **Delete Identity** endpoint:
@@ -158,6 +162,8 @@ To delete an identity, call the **Delete Identity** endpoint:
 ```
 DELETE https://YOUR_BLNK_INSTANCE_URL/identities/{identity_id}
 ```
+
+---
 
 ## Why use Identities
 

--- a/reference/create-api-key.mdx
+++ b/reference/create-api-key.mdx
@@ -10,8 +10,6 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 import Key from "/snippets/key.mdx";
 
-## Overview
-
 API keys allow you to enforce access control by granting specific scopes (permissions) to different services or applications, rather than using the master key for all operations.
 
 <Info>
@@ -103,4 +101,3 @@ curl --request POST \
 </ResponseExample>
 
 <NeedHelp />
-

--- a/reference/delete-api-key.mdx
+++ b/reference/delete-api-key.mdx
@@ -10,8 +10,6 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 import Key from "/snippets/key.mdx";
 
-## Overview
-
 Use this endpoint to revoke unused or expired API keys to maintain good security hygiene. 
 
 Revoking an API key immediately revokes access, so ensure you update your applications with a new API key before revoking the old one.

--- a/reference/get-api-key.mdx
+++ b/reference/get-api-key.mdx
@@ -10,8 +10,6 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 import Key from "/snippets/key.mdx";
 
-## Overview
-
 List all API keys for a specific owner. The `owner` query parameter is required—you cannot retrieve API keys without specifying the owner identifier. Use this endpoint to audit and manage your API keys. Note that the actual API key value is not returned for security reasons.
 
 <Info>

--- a/reference/get-health.mdx
+++ b/reference/get-health.mdx
@@ -9,8 +9,6 @@ noindex: true
 
 import NeedHelp from "/snippets/need-help.mdx";
 
-## Overview
-
 <Info>Available in version 0.10.3 and later. Public access (no authentication required) in v0.10.4.</Info>
 
 The **Health Check** endpoint allows you to verify that your Blnk API server is running and responsive. It is typically used for readiness and liveness checks in deployment environments (e.g., Docker, Kubernetes, load balancers).
@@ -30,4 +28,4 @@ curl --request GET \
 ```
 </ResponseExample>
 
-<NeedHelp /> 
+<NeedHelp />

--- a/sdks/go/examples.mdx
+++ b/sdks/go/examples.mdx
@@ -10,6 +10,8 @@ description: "Real life use-case implementation with the Go SDK."
 import NeedHelp from "/snippets/need-help.mdx";
 import Issues from "/snippets/sdk-issues.mdx";
 
+---
+
 ## Introduction
 
 In this examples guide, you'll learn how to implement common real life fintech use-cases with the Blnk Go SDK.

--- a/sdks/go/introduction.mdx
+++ b/sdks/go/introduction.mdx
@@ -14,6 +14,8 @@ Welcome to the Blnk SDK for Go Developer Guide. In this guide, you'll learn how 
 
 You'll also find examples of running different fintech use cases with our Go SDK.
 
+---
+
 ## Prerequisites
 
 Ensure that you have the following installed on your machine.

--- a/sdks/overview.mdx
+++ b/sdks/overview.mdx
@@ -9,6 +9,8 @@ icon: "component"
 import NeedHelp from "/snippets/need-help.mdx";
 import Issues from "/snippets/sdk-issues.mdx";
 
+---
+
 ## Introduction
 
 Learn how to get Blnk set up in your preferred language.

--- a/sdks/typescript/examples.mdx
+++ b/sdks/typescript/examples.mdx
@@ -10,6 +10,8 @@ description: "Real life use-case implementation with the TypeScript SDK."
 import NeedHelp from "/snippets/need-help.mdx";
 import Issues from "/snippets/sdk-issues.mdx";
 
+---
+
 ## Introduction
 
 In this examples guide, you'll learn how to implement common real life fintech use-cases with the Blnk TypeScript SDK. 

--- a/sdks/typescript/introduction.mdx
+++ b/sdks/typescript/introduction.mdx
@@ -14,6 +14,8 @@ Welcome to the Blnk SDK for TypeScript Developer Guide. In this guide, you'll le
 
 You'll also find examples of running different fintech use cases with our TypeScript SDK. 
 
+---
+
 ## Prerequisites
 
 Ensure that you have the following installed on your machine.

--- a/search/typesense/pagination.mdx
+++ b/search/typesense/pagination.mdx
@@ -9,6 +9,8 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 The `page` and `per_page` parameters control how search results are divided into manageable chunks. This is essential for handling large datasets efficiently and improving application performance.
 
+---
+
 ## Quick start
 
 Here's how to get the first 25 transactions:

--- a/search/typesense/sorting.mdx
+++ b/search/typesense/sorting.mdx
@@ -10,6 +10,8 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 The `sort_by` parameter controls the order of your search results. You can sort by any field in ascending or descending order, and combine up to three fields for multi-level sorting.
 
+---
+
 ## Quick start
 
 Here's how to sort transactions by creation date in descending order (newest first):

--- a/transactions/hash.mdx
+++ b/transactions/hash.mdx
@@ -13,13 +13,19 @@ In the world of digital transactions, maintaining the integrity and immutability
 
 Data hashing is a cryptographic process that converts input data of any size into a fixed-size string of characters, which is typically a digest representing the data. Blnk uses the SHA-256 hashing algorithm for this purpose, ensuring that each transaction is accompanied by a unique hash value that serves as its digital fingerprint.
 
+---
+
 ## How Blnk implements SHA-256 hashing
 
 When a transaction is processed in Blnk, the system generates a SHA-256 hash of the transaction's details, including the amount, source, destination, reference, and any other relevant information. This hash is then stored alongside the transaction record. The SHA-256 algorithm ensures that even the slightest change in the transaction details would result in a completely different hash, thereby safeguarding against unauthorized modifications.
 
+---
+
 ## Verifying transaction integrity
 
 Users can verify the integrity of a transaction by recomputing the SHA-256 hash of the transaction details and comparing it with the hash stored in the Blnk. If the computed hash matches the stored hash, the transaction is confirmed to be intact and unaltered.
+
+---
 
 ## Verifying a transaction hash
 
@@ -53,6 +59,8 @@ print(hash_value)
 
 Compare this `hash_value` with the hash provided by Blnk for the transaction. If they match, the transaction's integrity is verified.
 
+---
+
 ## Benefits of hashing transactions
 
 1. **Immutability**: Once a transaction is recorded with its hash, it cannot be altered without changing the hash. This makes every transaction in Blnk immutable and secure against tampering.
@@ -63,6 +71,7 @@ Compare this `hash_value` with the hash provided by Blnk for the transaction. If
 
 4. **Efficiency**: Hashing is a fast computational process, allowing for quick verification of transaction integrity without the need to compare all transaction details line by line.
 
+---
 
 ## Protecting Transaction Integrity in Blnk
 While SHA-256 ensures that transaction data remains verifiable, additional measures can help protect stored hashes from unauthorized modifications. Since Blnk records transaction hashes in its system, it is important to safeguard them against potential tampering. 

--- a/transactions/rates.mdx
+++ b/transactions/rates.mdx
@@ -24,6 +24,8 @@ What we'll cover …
 1. [Applying rates](#1-applying-rates)
 2. [Key considerations](#2-key-considerations)
 
+---
+
 ## 1: Applying rates
 
 Consider a transaction record sending USD 2,290.19 from a USD balance to a GBP balance. 

--- a/transactions/refunds.mdx
+++ b/transactions/refunds.mdx
@@ -15,6 +15,8 @@ Refunds only happen on transactions that have been applied. This means that the 
 
 When you refund a transaction, Blnk creates a new transaction record and switches the `source` and `destination` balances of the original transaction — debiting the amount from the balance that initially received it and crediting it to the balance that initially sent it.
 
+---
+
 ## Applying refunds
 
 Use the **refund-transaction** endpoint and pass the transaction_id of the transaction that you want to refund.
@@ -22,6 +24,8 @@ Use the **refund-transaction** endpoint and pass the transaction_id of the trans
 ```
 POST http://YOUR_BLNK_INSTANCE_URL/refund-transaction/{transaction_id}
 ```
+
+---
 
 ## Refunding transactions with multiple sources/destinations.
 

--- a/tutorials/digital-banking/cards.mdx
+++ b/tutorials/digital-banking/cards.mdx
@@ -9,7 +9,6 @@ description: "Learn how to implement online card payments with authorization and
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 In this tutorial, you’ll learn how to model online card payments using Blnk. 
 

--- a/tutorials/digital-banking/deposits-withdrawals.mdx
+++ b/tutorials/digital-banking/deposits-withdrawals.mdx
@@ -9,7 +9,6 @@ description: "Learn how to manage and track deposits and payouts with Blnk."
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 In this tutorial, you’ll learn how to implement deposits and payouts using the Blnk Ledger. You’ll explore and apply a variety of workflows to handle deposits and payouts seamlessly. This includes:
 

--- a/tutorials/digital-banking/lending.mdx
+++ b/tutorials/digital-banking/lending.mdx
@@ -9,7 +9,6 @@ description: "Learn how to manage & track loans and repayments with the Blnk Led
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 This tutorial provides a step-by-step guide to building a simple loan management system using Blnk Finance. You’ll learn how to: 
 

--- a/tutorials/examples/transfers.mdx
+++ b/tutorials/examples/transfers.mdx
@@ -8,6 +8,8 @@ description: "Managing transfers with side effects in the Blnk Ledger"
 
 import NeedHelp from "/snippets/need-help.mdx";
 
+---
+
 ## 1: Managing side effects with Refund
 
 When dealing with financial transactions, it's crucial to handle scenarios where things don't go as planned. One common situation is when a payment verification from a provider is not successful after funds have been moved. 
@@ -180,6 +182,8 @@ Refund processed successfully: {"refund_id":"rfd_1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4
 10. **Monitoring**: Set up monitoring and alerting for your webhook endpoint. This can help you quickly identify and respond to any issues in the payment verification and refund process.
 
 When you run this command, you should see output in your server logs similar to:
+
+---
 
 ## 2: Managing side effects with Inflight
 

--- a/tutorials/more/ai-billing.mdx
+++ b/tutorials/more/ai-billing.mdx
@@ -9,7 +9,6 @@ description: "Learn how to implement usage-based billing for AI products with to
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 This tutorial provides a step-by-step guide to building an AI billing system using Blnk Finance. You'll learn how to track token usage, calculate costs, and manage both prepaid and postpaid billing models.
 

--- a/tutorials/more/order-exchange.mdx
+++ b/tutorials/more/order-exchange.mdx
@@ -9,7 +9,6 @@ description: "Implementing a cryptocurrency order exchange system with the Blnk 
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 This guide demonstrates how to implement a secure and efficient cryptocurrency order exchange system with the Blnk Ledger. You'll learn how to handle order creation, escrow management, order matching, and atomic settlements.
 

--- a/tutorials/quick-start/escrow-payments.mdx
+++ b/tutorials/quick-start/escrow-payments.mdx
@@ -9,7 +9,6 @@ description: "Learn how to implement an escrow payment with Blnk."
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 In this tutorial, we’ll build a simple escrow payment workflow using Blnk’s inflight transaction feature. Here's what we'll do:
 

--- a/tutorials/quick-start/loyalty-points.mdx
+++ b/tutorials/quick-start/loyalty-points.mdx
@@ -9,7 +9,6 @@ description: "Learn how to implement a loyalty points system with Blnk."
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 In this tutorial, we will build a simple loyalty points system using the Blnk Ledger. Here's what we'll do:
 
@@ -134,6 +133,8 @@ curl --request POST \
   }'
 ```
 </CodeGroup>
+
+---
 
 ## Create balances for customer funds and loyalty points
 

--- a/tutorials/quick-start/savings-application.mdx
+++ b/tutorials/quick-start/savings-application.mdx
@@ -9,7 +9,6 @@ description: "Learn how to implement scheduled savings deposit with Blnk."
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 In this tutorial, you'll learn how to implement, monitor, and manage scheduled savings deposits with the Blnk ledger. Here's what we'll do:
 

--- a/tutorials/quick-start/wallet-management.mdx
+++ b/tutorials/quick-start/wallet-management.mdx
@@ -9,7 +9,6 @@ description: "Learn how to implement a complete wallet management system with Bl
 
 import RequestTutorial from "/snippets/request-tutorial.mdx"
 
-## Overview
 
 This tutorial will guide you through implementing a simple wallet management system using the Blnk Ledger. By the end, you'll have built a system that can:
 


### PR DESCRIPTION
Worker report:
**Changed files**
39 MDX docs files remain modified, including the follow-up edits in:
`backup/charge-card.mdx`, `changelog/v11-migration.mdx`, `changelog/v12-migration.mdx`, `changelog/v13-migration.mdx`, `reference/create-api-key.mdx`, `reference/delete-api-key.mdx`, `reference/get-api-key.mdx`, `reference/get-health.mdx`.

**What changed and why**
Removed the remaining `## Overview` headings across the docs, along with the divider immediately before each one. Preserved the intro paragraphs so they now start directly after imports/frontmatter, matching the new feedback.
