### PR TITLE
Lukas engineering task: pull-latest-on-blnkfinance-blnk-docs-and

### DIFF
--- a/cloud/new/api-key-management.mdx
+++ b/cloud/new/api-key-management.mdx
@@ -1,0 +1,68 @@
+---
+title: "API key management"
+sidebarTitle: "API key management"
+icon: "key-round"
+description: "Manage API keys and OAuth clients in Blnk Cloud, including filtering, expiration updates, revocation, and deletion."
+og:title: "API Key Management | Blnk Cloud Guide"
+og:description: "Create, filter, inspect, revoke, delete, and update expiration for API keys and OAuth clients in Blnk Cloud."
+---
+
+Use **Settings > API keys** to manage credentials for programmatic access to Blnk Cloud.
+
+The dashboard supports both:
+
+- **API keys** for server-to-server access.
+- **OAuth clients** for integrations that need a client ID and client secret.
+
+## Create a credential
+
+1. Open **Settings > API keys**.
+2. Click **Create API key**.
+3. Enter a name.
+4. Select the credential type: **API Key** or **OAuth**.
+5. Select one or more scopes.
+6. Choose an expiration.
+7. Create the credential.
+
+Cloud shows the full API key or OAuth client secret only once. You must confirm that you saved the credential before closing the reveal panel.
+
+## Scope selection
+
+Cloud loads the available scopes from your workspace and lets you select individual scopes or all scopes.
+
+Common scope groups include:
+
+| Group | Scopes |
+| --- | --- |
+| MCP | `mcp:read`, `mcp:write` |
+| Alerts | `alerts:read`, `alerts:write` |
+
+Only grant the scopes the credential needs.
+
+## Review credential details
+
+Open a credential from the API keys table to view:
+
+- Name and type.
+- Status: active, expired, or revoked.
+- Created date, last used date, and expiration date.
+- Credential ID.
+- Client ID for OAuth clients, or key prefix for API keys.
+- Assigned scopes.
+
+## Update expiration
+
+For active credentials, click **Update expiration** from the details panel. You can choose a new expiration or select **Never expires** to remove the expiration.
+
+## Revoke or delete
+
+Use **Revoke** when you want to disable a credential but keep it visible for reference.
+
+Use **Delete** when you want to remove the credential record from the table.
+
+Revoked or expired credentials cannot be used for authentication.
+
+## Filter credentials
+
+The API keys table supports filters and pagination. Date filters include created date, expiration date, and revoked date. Filters are reflected in the page URL so you can return to the same view.
+

--- a/cloud/new/query-agent-setup.mdx
+++ b/cloud/new/query-agent-setup.mdx
@@ -1,0 +1,43 @@
+---
+title: "Query Agent setup details"
+sidebarTitle: "Query Agent setup"
+icon: "server-cog"
+description: "Use the Query Agent setup page to connect a self-hosted Blnk Core instance to Blnk Cloud."
+og:title: "Query Agent Setup Details | Blnk Cloud Guide"
+og:description: "Review Query Agent connection details, copy the agent key, run the setup command, and monitor connection status in Blnk Cloud."
+---
+
+The Query Agent setup page helps you connect a self-hosted Blnk Core instance to Cloud. Open it from **Settings > Instances** by using the instance action menu or details panel, then selecting **View setup details**.
+
+## Connection details
+
+The setup page shows the connection values for the selected instance:
+
+- **Agent URL** - the Cloud endpoint the Query Agent connects to.
+- **Agent secret key** - the one-time connection key for the instance.
+- **Agent status** - the current connection state.
+
+Use the copy action beside the secret key instead of retyping it. Treat the secret key like a credential.
+
+## Run the Query Agent
+
+The dashboard provides setup commands for common platforms, including Docker, Linux, macOS, and Windows. Use the command for the machine where your Query Agent will run.
+
+When you run the agent, keep the setup page open. Cloud polls the instance connection status every 10 seconds and updates the status automatically.
+
+## Statuses
+
+| Status | Meaning |
+| --- | --- |
+| Listening | Cloud is waiting for the Query Agent to connect. |
+| Connected | The Query Agent is connected and the instance can be selected in Cloud. |
+| Error | Cloud could not confirm the Query Agent connection or the instance is disconnected. |
+
+When the status changes to **Connected**, Cloud stores the instance as the selected instance and refreshes the instance list.
+
+## Troubleshooting
+
+- Confirm that the instance ID in the setup URL matches the instance you are connecting.
+- Confirm that the agent URL and secret key are copied from the setup page for that instance.
+- Check network access from the agent host to Cloud.
+- If the status stays disconnected, return to **Settings > Instances**, open the instance, and review its Core URL and connection settings.

--- a/cloud/new/review-summary.mdx
+++ b/cloud/new/review-summary.mdx
@@ -1,0 +1,36 @@
+---
+title: "Cloud dashboard docs review"
+sidebarTitle: "Review summary"
+icon: "list-checks"
+description: "Summary of new Cloud guide docs created from dashboard source evidence."
+og:title: "Cloud Dashboard Docs Review | Blnk Cloud Guide"
+og:description: "Review summary for new Cloud guide docs created from Blnk dashboard source evidence."
+---
+
+This review used the refreshed `blnkfinance/blnk-dashboard` checkout at `/root/sandbox/blnkfinance__blnk-dashboard` as source evidence. Only new docs were created under `/cloud/new/`; existing docs pages were not edited.
+
+## New docs created
+
+| New doc | Dashboard evidence used | Why it was added |
+| --- | --- | --- |
+| `/cloud/new/workspace-switching` | `hooks/use-switch-workspace.tsx`, `components/blnk-ui/side-nav/user-dropdown.tsx`, `components/blnk-ui/create-new-workspace-form/index.tsx`, `components/layouts/setup-layout.tsx`, `components/pages/cloud/switching/index.tsx` | Existing workspace docs mention multiple workspaces briefly, but dashboard behavior includes token switching, selected-instance clearing, cache refresh, loading/error states, and automatic switching after creating a workspace. |
+| `/cloud/new/query-agent-setup` | `pages/cloud/settings/instances/setup-query-agent.tsx`, `components/pages/cloud/setup-query-agent/index.tsx`, `components/blnk-ui/code-snippet/docker-run-query-agent.tsx`, `components/blnk-ui/code-snippet/linux-run-query-agent.tsx`, `components/blnk-ui/code-snippet/mac-os-run-query-agent.tsx`, `components/blnk-ui/code-snippet/windows-run-query-agent.tsx` | Existing instance docs reference setup details, but the dashboard has a dedicated setup flow with connection details, a copied secret key, platform commands, 10-second polling, and status handling. |
+| `/cloud/new/watch-settings` | `pages/cloud/settings/watch/index.tsx` | Cloud settings exposes a Watch entry point and download CTA. Watch docs exist as a separate tab, but the Cloud settings path was not documented as a Cloud guide. |
+| `/cloud/new/api-key-management` | `pages/cloud/settings/api-keys/index.tsx`, `components/pages/cloud/settings/api-keys/index.tsx`, `components/pages/cloud/settings/api-keys/create-api-key-modal.tsx`, `components/pages/cloud/settings/api-keys/api-key-details-modal.tsx`, `components/pages/cloud/settings/api-keys/update-expiration-dialog.tsx`, `components/pages/cloud/settings/api-keys/reveal-key-modal.tsx` | Existing API key/OAuth docs cover creation and revocation basics, but the dashboard also supports filtering, status review, detail panels, expiration updates, deletion, one-time reveal confirmation, and OAuth/API key management in one table. |
+
+## Local docs paths checked
+
+- `docs.json`
+- `cloud/start/guide.mdx`
+- `cloud/organization/workspace.mdx`
+- `cloud/instances/overview.mdx`
+- `cloud/auth/api-keys.mdx`
+- `cloud/auth/oauth.mdx`
+- `watch/quick-start.mdx`
+- `watch/mental-model.mdx`
+
+## Notes
+
+- The dashboard also contains a browser-only **Feature flags** settings page guarded by the `browser-flags` feature flag. It was not documented because it appears to be an internal or experimental UI control rather than a customer-facing Cloud feature.
+- `pages/cloud/settings/referrals/index.tsx` redirects to profile, so no referrals guide was created from dashboard evidence.
+

--- a/cloud/new/watch-settings.mdx
+++ b/cloud/new/watch-settings.mdx
@@ -1,0 +1,44 @@
+---
+title: "Watch in Cloud settings"
+sidebarTitle: "Watch settings"
+icon: "eye"
+description: "Find the Watch entry point in Blnk Cloud settings and use it to get the open-source transaction monitoring engine."
+og:title: "Watch in Cloud Settings | Blnk Cloud Guide"
+og:description: "Use the Watch settings page in Blnk Cloud to learn about and download Blnk Watch for transaction monitoring."
+---
+
+Blnk Cloud includes a **Watch** page in Settings. Watch is Blnk's open-source transaction monitoring engine for defining rules and policies around ledger activity.
+
+## Open the Watch page
+
+1. In Blnk Cloud, open **Settings**.
+2. Select **Watch**.
+
+The page introduces Watch and links to the Watch repository.
+
+## Download Watch
+
+Click **Download watch** to open the Watch GitHub repository:
+
+```text
+https://github.com/blnkfinance/watch
+```
+
+Use Watch as a standalone transaction monitoring tool or extend it for your own monitoring workflows.
+
+## Example rule
+
+The dashboard shows a sample rule that blocks transactions above a threshold:
+
+```text
+rule AmountLimitCheck {
+  description "Monitors for transaction amounts beyond $500."
+  when amount > 500
+  then block
+    score 0.75
+    reason "Transaction exceeds the $500 limit in any currency"
+}
+```
+
+For full Watch setup and rule syntax, use the Watch docs in this documentation site.
+

--- a/cloud/new/workspace-switching.mdx
+++ b/cloud/new/workspace-switching.mdx
@@ -1,0 +1,49 @@
+---
+title: "Workspace switching"
+sidebarTitle: "Workspace switching"
+icon: "shuffle"
+description: "Switch between Blnk Cloud workspaces and create another workspace from the dashboard."
+og:title: "Workspace Switching | Blnk Cloud Guide"
+og:description: "Switch between Blnk Cloud workspaces, understand what changes during the switch, and create a new workspace from the dashboard."
+---
+
+Blnk Cloud lets you belong to more than one workspace. Use workspace switching when you need to move between organizations without signing out.
+
+## Switch workspace
+
+1. Click the workspace name or logo at the top of the left sidebar.
+2. Open **Switch workspace**.
+3. Select the workspace you want to use.
+
+The active workspace is marked in the list. While the switch is in progress, the selected workspace shows a loading state.
+
+After the switch succeeds, Blnk Cloud:
+
+- Updates your session token for the selected organization.
+- Clears the previously selected instance from browser storage.
+- Clears cached Cloud data except the organization list.
+- Redirects you through setup if the selected workspace still needs setup, or back into Cloud after setup checks complete.
+
+If the selected workspace cannot be switched to, Cloud shows a switch failure message.
+
+## Add workspace
+
+You can create another workspace from the same workspace menu.
+
+1. Click the workspace name or logo at the top of the left sidebar.
+2. Open **Switch workspace**.
+3. Click **Add workspace**.
+4. Enter the organization name, size, team, and country.
+5. Click **Create workspace**.
+
+After the workspace is created, Cloud automatically switches you into the new workspace.
+
+## What to check after switching
+
+Because each workspace has its own organization, subscription, team, instances, apps, and API credentials, confirm that:
+
+- The correct workspace name appears in the sidebar.
+- The correct instance is selected before you create or review ledger data.
+- Your subscription and setup status are complete for that workspace.
+- Any app, API key, or OAuth credential you plan to use belongs to the active workspace.
+


### PR DESCRIPTION
## Summary
- Pull latest on blnkfinance/blnk-docs and blnkfinance/blnk-dashboard. Use blnkfinance/blnk-dashboard as the source of truth to identify Cloud features and functionality that exist in the dashboard but are missing or outdated in the docs, including workspace switching. Create new Cloud guide docs only, saved under /cloud/new/ for easy reference and review. Do not directly edit existing documentation pages. Include a short review summary listing the new docs created and the dashboard evidence used for each.
- Updated 1 file, including `cloud/new/`.

## Validation
- No standard validation command was detected for this checkout.

## Notes
- Review details and sandbox artifacts are available in the internal approval thread.