### PR TITLE
Lukas engineering task: pull-latest-for-blnkfinance-blnk-docs-an

### DIFF
--- a/cloud/new/dashboard-gap-review.mdx
+++ b/cloud/new/dashboard-gap-review.mdx
@@ -1,0 +1,61 @@
+---
+title: "Cloud Dashboard Gap Review"
+sidebarTitle: "Dashboard gap review"
+icon: "clipboard-check"
+description: "Review Cloud dashboard features that need new or updated documentation."
+og:title: "Cloud Dashboard Gap Review | Blnk Cloud Guide"
+og:description: "Cloud documentation gaps discovered by comparing the dashboard source with the docs."
+---
+
+This review compares the current Cloud docs with the dashboard source in `blnkfinance/blnk-dashboard` at `ab36f8b2`.
+
+## Source paths checked
+
+Dashboard evidence:
+
+- `utils/links.ts`
+- `components/blnk-ui/settings-side-nav/index.tsx`
+- `pages/cloud/settings/mcp/index.tsx`
+- `pages/cloud/settings/watch/index.tsx`
+- `pages/cloud/settings/flags/index.tsx`
+- `hooks/use-ui-feature-flags.ts`
+- `components/pages/cloud/settings/table/index.tsx`
+- `components/pages/cloud/settings/table/instance-details-modal.tsx`
+- `components/pages/cloud/setup-query-agent/index.tsx`
+- `components/blnk-ui/code-snippet/docker-run-query-agent.tsx`
+
+Docs paths checked:
+
+- `docs.json`
+- `cloud/integrations/mcp.mdx`
+- `cloud/auth/api-keys.mdx`
+- `cloud/auth/oauth.mdx`
+- `cloud/instances/create.mdx`
+- `cloud/instances/deploy.mdx`
+- `cloud/instances/whitelist.mdx`
+- `cloud/organization/workspace.mdx`
+- `cloud/account/security.mdx`
+
+## Gaps found
+
+| Area | Dashboard behavior | Current docs state | Suggested action |
+| --- | --- | --- | --- |
+| MCP dashboard setup | Settings > MCP exposes an endpoint shaped as `https://api.cloud.blnkfinance.com/mcp/{instance_id}` and a Cursor JSON sample that sends `X-API-Key`. It also lists 33 tools. | `cloud/integrations/mcp.mdx` uses `Authorization: Bearer YOUR_API_KEY` in the Cursor sample and lists `get_transaction_by_reference`, which is not in the dashboard's 33-tool table. | Product/engineering should confirm the accepted MCP auth header and canonical tool list, then update the live MCP docs. Draft guide: `/cloud/new/mcp-dashboard-setup`. |
+| Feature flags | Settings > Feature flags appears only when the remote `browser-flags` feature is enabled. The current browser-local flag is `apps`, described as "Manage the tools connected to your Cloud workspace." | No Cloud docs page explains browser-only feature flags or that this page can be hidden. | Add an internal-facing or beta-facing guide if this should be documented publicly. Draft guide: `/cloud/new/settings-feature-flags-watch`. |
+| Watch in Cloud settings | Settings > Watch introduces Watch and links to `https://github.com/blnkfinance/watch`. | Watch has its own docs tab, but the Cloud settings navigation is not documented as a discovery path. | Add a short Cloud settings note if Watch should be discoverable from Cloud docs. Draft guide: `/cloud/new/settings-feature-flags-watch`. |
+| Managed instance operations | Managed instance rows support allowed IP management, direct DB access generation/revocation, destroy deployment, and upgrade prompts. DB access is disabled until at least one IP is whitelisted. Sandbox deployments hide direct DB access and allowed IP actions. | Direct DB access and IP whitelisting exist in docs, but the current dashboard-specific gates and upgrade caveats are scattered or missing. | Update the managed instance docs after confirmation. Draft guide: `/cloud/new/instance-operations-review`. |
+| Query Agent setup | Dashboard setup details copy a connection key, poll instance status every 10 seconds, and use a Docker command with `CONNECTION_KEY`. | `cloud/instances/create.mdx` covers Query Agent, but the dashboard flow now emphasizes the setup details page and auto-completion when connected. | Fold the dashboard flow language into the self-hosted instance guide. Draft guide: `/cloud/new/instance-operations-review`. |
+| Workspace deletion | Settings > Workspace lets admins schedule workspace deletion after typing the workspace name. | `cloud/organization/workspace.mdx` covers workspace updates and multiple workspaces, but not deletion. | Confirm whether destructive workspace deletion should be public docs, admin-only docs, or support-led. |
+| Referrals | `/cloud/settings/referrals` exists but redirects to `/cloud/settings/profile`; the nav item is commented out. | Referrals are not in docs. | No docs update unless the product re-enables referrals. |
+| Branching | Branch-out code exists behind `SHOW_BRANCHING = false`. | `cloud/instances/branching.mdx` exists. | Confirm whether branching should remain documented if disabled in the dashboard. |
+
+## Product confirmations needed
+
+1. MCP authentication: should dashboard client configuration use `X-API-Key`, `Authorization: Bearer`, or both?
+2. MCP tool list: should the docs include `get_transaction_by_reference` even though the dashboard table does not list it?
+3. Feature flags: should the browser-only feature flags page be public documentation, internal support documentation, or omitted?
+4. Watch: should Cloud docs mention Settings > Watch, or should Watch remain documented only in the Watch tab?
+5. Instance upgrades: what is the expected data behavior for production upgrades, and should sandbox upgrades always be described as starting fresh?
+6. Branching: should the existing branching docs stay visible while the dashboard action is disabled?
+7. Workspace deletion: should users be guided to schedule deletion themselves, or should this remain support-led?
+

--- a/cloud/new/instance-operations-review.mdx
+++ b/cloud/new/instance-operations-review.mdx
@@ -1,0 +1,95 @@
+---
+title: "Instance Operations Review"
+sidebarTitle: "Instance operations review"
+icon: "server-cog"
+description: "Draft Cloud instance operations guide based on the current dashboard."
+og:title: "Instance Operations Review | Blnk Cloud Guide"
+og:description: "Draft guide for Cloud instance actions, Query Agent setup, direct DB access, IP allowlists, and upgrades."
+---
+
+<Warning>
+This is a draft review guide. It is intentionally separate from the live instance docs so product and engineering can confirm the current dashboard behavior before existing pages are edited.
+</Warning>
+
+The dashboard exposes different actions for self-hosted Agent instances and managed Cloud deployments.
+
+## Self-hosted Agent instances
+
+For instances where `connection_type` is `agent` and there is no `deployment_id`, the dashboard shows:
+
+- **View details**
+- **View setup guide**
+- **Edit**
+- **Terminate**
+
+The **View setup guide** action opens:
+
+```text
+/cloud/settings/instances/setup-query-agent?id=INSTANCE_ID
+```
+
+The setup page shows the connection key, polls the instance status every 10 seconds, and marks the instance as connected when the API reports `connected`.
+
+### Query Agent command
+
+The dashboard Docker example uses `CONNECTION_KEY`:
+
+```bash
+docker run -d --name blnk-agent-YOUR_INSTANCE_ID \
+  -e DB_URL='<YOUR_DATABASE_URL>' \
+  -e CONNECTION_KEY='<YOUR_CONNECTION_KEY>' \
+  blnkfinance/query-agent:latest
+```
+
+Use a PostgreSQL URL in this format:
+
+```text
+postgres://<user>:<password>@<host>:<port>/<db-name>?sslmode=<mode>
+```
+
+The dashboard tells users they can leave the setup page open or navigate away; the connection status auto-completes when the agent connects.
+
+## Managed deployments
+
+For connected managed deployments, the dashboard can show:
+
+- **Manage allowed IPs**
+- **Generate DB access**
+- **Revoke DB access**
+- **Destroy**
+- **Upgrade deployment**, when an upgrade is available
+
+These actions are gated by deployment type and state.
+
+| Action | Dashboard condition |
+| --- | --- |
+| Manage allowed IPs | Managed deployment, connected, not sandbox, not currently upgrading |
+| Generate DB access | Managed deployment, connected, not sandbox, no existing DB access, at least one allowed IP |
+| Revoke DB access | Managed deployment, connected, not sandbox, existing DB access |
+| Destroy deployment | Managed deployment, not still deploying |
+| Upgrade deployment | Managed deployment with an available newer image version |
+
+<Info>
+The dashboard disables **Generate DB access** until at least one IP address is allowed. The disabled tooltip says to add a whitelisted IP address before generating database access.
+</Info>
+
+## Destructive actions
+
+The dashboard distinguishes these destructive actions:
+
+- **Terminate instance** removes a self-hosted instance connection from the workspace. The Core data remains intact.
+- **Destroy deployment** permanently deletes a managed deployment and its data. The confirmation requires typing the instance name.
+- **Revoke DB access** permanently revokes generated direct database credentials for a deployment.
+
+## Upgrade prompts
+
+The dashboard can initiate deployment upgrades. If the backend returns `upgrade_status: "skipped"`, the UI reports that the deployment is already up to date. Otherwise, it reports that the upgrade has started.
+
+The instance details modal includes a sandbox warning during upgrade confirmation:
+
+> Sandbox environments start fresh with each upgrade.
+
+<Note>
+Product confirmation needed: document the exact production upgrade data behavior and whether the sandbox "starts fresh" warning applies only to sandbox deployments.
+</Note>
+

--- a/cloud/new/mcp-dashboard-setup.mdx
+++ b/cloud/new/mcp-dashboard-setup.mdx
@@ -1,0 +1,113 @@
+---
+title: "MCP Dashboard Setup"
+sidebarTitle: "MCP dashboard setup"
+icon: "cpu"
+description: "Draft update for the MCP setup flow shown in the current Cloud dashboard."
+og:title: "MCP Dashboard Setup | Blnk Cloud Guide"
+og:description: "Draft Cloud MCP setup guide based on the current Blnk dashboard implementation."
+---
+
+<Warning>
+This is a draft guide for review. It reflects the current dashboard source and should not replace the live MCP guide until the authentication header and tool list are confirmed.
+</Warning>
+
+Blnk MCP lets an MCP-compatible AI client connect to your selected Blnk Core instance through Blnk Cloud.
+
+In the dashboard, go to **Settings > MCP** to copy:
+
+- Your MCP endpoint
+- A Cursor-ready MCP server configuration
+- The API key scope requirements
+- The supported MCP tool list
+
+## Endpoint format
+
+The dashboard builds the endpoint from the selected instance:
+
+```text
+https://api.cloud.blnkfinance.com/mcp/YOUR_INSTANCE_ID
+```
+
+If the dashboard cannot find a selected instance in the browser, it shows `YOUR_INSTANCE_ID` as a placeholder.
+
+## API key scopes
+
+Create an API key from **Settings > API keys** with these scopes:
+
+- `mcp:read`
+- `mcp:write`
+
+Use `mcp:read` for read-only workflows and add `mcp:write` when the AI client should create or mutate records through MCP.
+
+## Cursor setup shown in the dashboard
+
+The current dashboard renders this Cursor configuration:
+
+```json
+{
+  "mcpServers": {
+    "blnk": {
+      "url": "https://api.cloud.blnkfinance.com/mcp/YOUR_INSTANCE_ID",
+      "headers": {
+        "X-API-Key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+To configure Cursor:
+
+1. Open Cursor settings.
+2. Go to **Features > MCP Servers**.
+3. Click **Add Server**.
+4. Paste the Blnk MCP configuration.
+5. Replace `YOUR_INSTANCE_ID` and `YOUR_API_KEY`.
+
+<Note>
+The existing live docs show an `Authorization: Bearer YOUR_API_KEY` header for this flow. The dashboard currently shows `X-API-Key`. Product or API engineering should confirm the canonical header before this draft is promoted.
+</Note>
+
+## Tools listed in the dashboard
+
+The dashboard lists 33 MCP tools:
+
+| Tool | Description |
+| --- | --- |
+| `create_ledger` | Create a new ledger |
+| `get_ledger` | Get ledger by ID |
+| `list_ledgers` | List all ledgers |
+| `create_balance` | Create a balance |
+| `get_balance` | Get balance by ID |
+| `list_balances` | List all balances |
+| `record_transaction` | Record a transaction |
+| `get_transaction` | Get transaction by ID |
+| `commit_inflight` | Commit inflight transaction |
+| `void_inflight` | Void inflight transaction |
+| `refund_transaction` | Refund a transaction |
+| `schedule_transaction` | Schedule a transaction |
+| `bulk_transactions` | Process bulk transactions |
+| `search` | Search across entities |
+| `create_identity` | Create an identity |
+| `get_identity` | Get identity by ID |
+| `list_identities` | List all identities |
+| `update_identity` | Update an identity |
+| `delete_identity` | Delete an identity |
+| `query_transactions` | Query with filters |
+| `query_balances` | Query balances |
+| `query_ledgers` | Query ledgers |
+| `query_identities` | Query identities |
+| `create_view` | Create a saved view |
+| `list_views` | List all views |
+| `get_view` | Get view by ID |
+| `update_view` | Update a view |
+| `delete_view` | Delete a view |
+| `create_visualization` | Create visualization |
+| `list_visualizations` | List visualizations |
+| `get_visualization_data` | Get chart data |
+| `delete_visualization` | Delete visualization |
+
+<Note>
+The live docs also list `get_transaction_by_reference`. The dashboard tool table does not. Confirm whether that tool is supported before updating the canonical MCP reference.
+</Note>
+

--- a/cloud/new/settings-feature-flags-watch.mdx
+++ b/cloud/new/settings-feature-flags-watch.mdx
@@ -1,0 +1,59 @@
+---
+title: "Settings Feature Flags and Watch"
+sidebarTitle: "Feature flags and Watch"
+icon: "settings-2"
+description: "Draft Cloud settings guide for browser feature flags and the Watch discovery page."
+og:title: "Settings Feature Flags and Watch | Blnk Cloud Guide"
+og:description: "Draft documentation for Cloud settings pages found in the current dashboard but not represented in the Cloud docs."
+---
+
+<Warning>
+This is a draft review guide. It describes dashboard behavior that may be beta-only or intentionally hidden.
+</Warning>
+
+The current dashboard settings sidebar includes Cloud settings pages that are missing or only indirectly represented in the docs.
+
+## Feature flags
+
+The dashboard has a **Settings > Feature flags** page, but it is only visible when the remote `browser-flags` feature is enabled.
+
+Feature flags on this page are browser-local. The current flag is:
+
+| Flag | Description | Storage key |
+| --- | --- | --- |
+| Apps | Manage the tools connected to your Cloud workspace. | `ui-feature-flag:apps` |
+
+Turning a flag on stores it in the browser's `localStorage`. The setting applies only to that browser and is broadcast to other open tabs in the same browser session.
+
+<Note>
+Product confirmation needed: decide whether this page should be documented publicly. Because it controls hidden UI and is gated by a remote feature flag, it may be better suited to internal support docs until the feature is generally available.
+</Note>
+
+## Watch in Cloud settings
+
+The dashboard has a **Settings > Watch** page titled **Introducing Watch**. It describes Watch as a lightweight, open-source transaction monitoring engine for defining rules and policies around ledger activity.
+
+The page links to:
+
+```text
+https://github.com/blnkfinance/watch
+```
+
+It also shows an example rule:
+
+```text
+rule AmountLimitCheck {
+  description "Monitors for transaction amounts beyond $500."
+  when amount > 500
+  then block
+    score 0.75
+    reason "Transaction exceeds the $500 limit in any currency"
+}
+```
+
+The docs already have a dedicated Watch tab. What is missing is the Cloud dashboard discovery path: users can also find Watch from **Settings > Watch**.
+
+## Referrals
+
+The dashboard contains a `/cloud/settings/referrals` route, but it redirects to `/cloud/settings/profile`, and the sidebar item is commented out. This should not be documented unless the product re-enables referrals.
+


### PR DESCRIPTION
## Summary
- Pull latest for blnkfinance/blnk-docs and blnkfinance/blnk-dashboard. Use blnkfinance/blnk-dashboard as the source of truth to review Cloud features and functionality that exist in the dashboard but are missing or outdated in blnkfinance/blnk-docs. Create new cloud guide docs only under /cloud/new/ in blnkfinance/blnk-docs for easy review. Do not directly edit existing docs pages. Do not make any edits to blnkfinance/blnk-dashboard. Include a concise summary of discovered gaps, files created, and any features needing product confirmation.
- Updated 1 file, including `cloud/new/`.

## Validation
- No standard validation command was detected for this checkout.

## Notes
- Review details and sandbox artifacts are available in the internal approval thread.