### PR TITLE
docs(typescript): split SDK resource pages and slim install hub

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -679,6 +679,18 @@
                   "sdks/typescript",
                   "changelog/blnk-ts"
                 ]
+              },
+              {
+                "group": "Resource methods",
+                "pages": [
+                  "sdks/typescript/ledgers",
+                  "sdks/typescript/balances",
+                  "sdks/typescript/transactions",
+                  "sdks/typescript/identities",
+                  "sdks/typescript/reconciliation",
+                  "sdks/typescript/search",
+                  "sdks/typescript/balance-monitors"
+                ]
               }
             ]
           },

--- a/sdks/typescript.mdx
+++ b/sdks/typescript.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started with the TypeScript SDK"
 description: "Install the Blnk TypeScript SDK, run your first transaction, and find the Core docs for every SDK method."
-sidebarTitle: "TypeScript"
+sidebarTitle: "Install"
 icon: "code"
 "og:title": "Getting Started with the TypeScript SDK • Blnk SDK Documentation"
 "og:description": "Install the Blnk TypeScript SDK, initialize the client, and record your first transaction in TypeScript."
@@ -56,6 +56,25 @@ const blnk = BlnkInit(apiKey, {
   timeout: 10000,
 });
 ```
+
+</Step>
+
+<Step title="Verify connectivity">
+
+Confirm Core is reachable before you post a transaction. The health endpoint does not require authentication on local instances.
+
+```typescript wrap
+const health = await blnk.System.health();
+
+if (health.status !== 200 || health.data?.status !== 'UP') {
+  console.error('Core is not reachable:', health.message);
+  process.exit(1);
+}
+
+console.log('Core status:', health.data.status);
+```
+
+See [Health check](/reference/get-health) for deployment and probe notes.
 
 </Step>
 
@@ -156,8 +175,9 @@ Reference the Core documentation to understand how each API works. This section 
 - `blnk.Reconciliation`
 - `blnk.Search`
 - `blnk.Identity`
+- `blnk.System`
 
-Call methods on the service that matches the resource you need. The [endpoint map](#endpoint-map) lists each method and links to its API reference page.
+Call methods on the service that matches the resource you need. Browse [**Resource methods**](/sdks/typescript/transactions) in the sidebar for method-level examples and Core API links.
 
 ### Request field names
 
@@ -203,299 +223,6 @@ CommonJS also works and matches the [GitHub examples](https://github.com/blnkfin
 ```javascript wrap
 const { BlnkInit } = require('@blnkfinance/blnk-typescript');
 ```
-
----
-
-## Endpoint map
-
-Each SDK method calls a Blnk Core HTTP endpoint. Use this map to find the SDK method for an operation and open its reference page for field definitions and business logic.
-
-<Tip>
-Read the linked Core reference page for each method to understand required fields, validation rules, and behavior.
-</Tip>
-
-<Tabs>
-<Tab title="Ledgers">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Ledgers.create` | [Create ledger](/reference/create-ledger) |
-| `blnk.Ledgers.get` | [Get ledger](/reference/get-ledger) |
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.Ledgers.create({
-  name: 'Customer accounts',
-  meta_data: { project_owner: 'MyApp' },
-});
-```
-
-```typescript Get wrap
-const response = await blnk.Ledgers.get(
-  'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Balances">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.LedgerBalances.create` | [Create balance](/reference/create-balance) |
-| `blnk.LedgerBalances.get` | [Get balance](/reference/get-balance) |
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.LedgerBalances.create({
-  ledger_id: 'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
-  currency: 'USD',
-});
-```
-
-```typescript Get wrap
-const response = await blnk.LedgerBalances.get(
-  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Transactions">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Transactions.create` | [Create transaction](/reference/create-transaction) |
-| `blnk.Transactions.createBulk` | [Bulk transactions](/reference/bulk-transactions) |
-| `blnk.Transactions.updateStatus` | [Update inflight](/reference/update-inflight) |
-| `blnk.Transactions.refund` | [Refund transaction](/reference/refund-transaction) |
-
-For bulk transaction concepts and options, see the [Bulk transactions guide](/transactions/bulk-transactions).
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.Transactions.create({
-  amount: 1000,
-  precision: 100,
-  currency: 'USD',
-  source: '@FundingPool',
-  destination: '@MyBalance',
-  reference: 'payment_001',
-  allow_overdraft: true,
-});
-```
-
-```typescript CreateBulk wrap expandable
-const response = await blnk.Transactions.createBulk({
-  atomic: true,
-  transactions: [
-    {
-      amount: 1000,
-      precision: 100,
-      currency: 'USD',
-      source: '@source_1',
-      destination: '@dest_1',
-      reference: 'bulk_001',
-      description: 'Payment 1',
-    },
-    {
-      amount: 2000,
-      precision: 100,
-      currency: 'USD',
-      source: '@source_2',
-      destination: '@dest_2',
-      reference: 'bulk_002',
-      description: 'Payment 2',
-    },
-  ],
-});
-```
-
-```typescript UpdateStatus wrap
-const response = await blnk.Transactions.updateStatus(
-  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
-  { status: 'commit' },
-);
-```
-
-```typescript Refund wrap
-const response = await blnk.Transactions.refund(
-  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Reconciliation">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Reconciliation.upload` | [Upload data](/reference/upload-data) |
-| `blnk.Reconciliation.createMatchingRule` | [Create matching rule](/reference/create-matching-rule) |
-| `blnk.Reconciliation.run` | [Start reconciliation](/reference/start-reconciliation) |
-
-<CodeGroup>
-```typescript Upload wrap
-const response = await blnk.Reconciliation.upload(
-  'statement.csv',
-  'stripe',
-);
-```
-
-```typescript CreateMatchingRule wrap
-const response = await blnk.Reconciliation.createMatchingRule({
-  name: 'Amount match',
-  description: 'Match by amount',
-  criteria: [{ field: 'amount', operator: 'equals', allowable_drift: 0.01 }],
-});
-```
-
-```typescript Run wrap
-const response = await blnk.Reconciliation.run({
-  upload_id: 'upl_f3a8b2c1-9d4e-4a7b-8c6e-1f2d3e4a5b6c',
-  strategy: 'one_to_one',
-  dry_run: true,
-  grouping_criteria: 'amount',
-  matching_rule_ids: ['rule_abc123'],
-});
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Identities">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Identity.create` | [Create identity](/reference/create-identity) |
-| `blnk.Identity.get` | [Get identity](/reference/get-identity) |
-| `blnk.Identity.list` | [Get identity](/reference/get-identity) |
-| `blnk.Identity.update` | [Edit identity](/reference/edit-identity) |
-
-<CodeGroup>
-```typescript Create wrap expandable
-const response = await blnk.Identity.create({
-  identity_type: 'individual',
-  first_name: 'Jane',
-  last_name: 'Doe',
-  gender: 'female',
-  nationality: 'US',
-  dob: new Date('1990-01-15'),
-  email_address: 'jane@example.com',
-  phone_number: '+1234567890',
-  category: 'customer',
-  street: '123 Main St',
-  city: 'New York',
-  state: 'NY',
-  country: 'USA',
-  post_code: '10001',
-});
-```
-
-```typescript Get wrap
-const response = await blnk.Identity.get(
-  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
-);
-```
-
-```typescript List wrap
-const response = await blnk.Identity.list();
-```
-
-```typescript Update wrap
-const response = await blnk.Identity.update(
-  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
-  { first_name: 'Jane', last_name: 'Smith' },
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Typesense Search">
-
-Use `Search.search` for full-text search powered by Typesense.
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Search.search(params, collection)` | [Search via Typesense](/reference/search-typesense) |
-
-Pass a collection name as the second argument: `'ledgers'`, `'transactions'`, or `'balances'`.
-
-<CodeGroup>
-```typescript Transactions wrap
-const response = await blnk.Search.search(
-  { q: 'payment', per_page: 20 },
-  'transactions',
-);
-```
-
-```typescript Balances wrap
-const response = await blnk.Search.search(
-  { q: 'USD', per_page: 20 },
-  'balances',
-);
-```
-
-```typescript Ledgers wrap
-const response = await blnk.Search.search(
-  { q: 'customer', per_page: 20 },
-  'ledgers',
-);
-```
-</CodeGroup>
-
-For structured DB queries without Typesense, use the [Search via DB](/reference/search-db) HTTP API directly.
-
-</Tab>
-<Tab title="Monitors">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.BalanceMonitor.create` | [Create balance monitor](/reference/create-balance-monitor) |
-| `blnk.BalanceMonitor.get` | [Get balance monitor](/reference/get-balance-monitor) |
-| `blnk.BalanceMonitor.list` | [Get balance monitor](/reference/get-balance-monitor) |
-| `blnk.BalanceMonitor.update` | [Edit balance monitor](/reference/edit-balance-monitor) |
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.BalanceMonitor.create({
-  balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-  condition: {
-    field: 'credit_balance',
-    operator: '>',
-    value: 1000,
-    precision: 100,
-  },
-});
-```
-
-```typescript Get wrap
-const response = await blnk.BalanceMonitor.get(
-  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
-);
-```
-
-```typescript List wrap
-const response = await blnk.BalanceMonitor.list();
-```
-
-```typescript Update wrap
-const response = await blnk.BalanceMonitor.update(
-  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
-  {
-    balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-    condition: {
-      field: 'credit_balance',
-      operator: '<',
-      value: 500,
-      precision: 100,
-    },
-  },
-);
-```
-</CodeGroup>
-
-</Tab>
-</Tabs>
 
 ---
 

--- a/sdks/typescript/balance-monitors.mdx
+++ b/sdks/typescript/balance-monitors.mdx
@@ -1,0 +1,102 @@
+---
+title: "Balance monitors"
+sidebarTitle: "Balance monitors"
+icon: "bell"
+description: "Use the Blnk TypeScript SDK to create and manage balance monitors on your Core instance."
+"og:title": "Balance monitors • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create and manage balance monitors on your Core instance."
+---
+
+Use `blnk.BalanceMonitor` to watch balance levels and trigger webhooks when conditions are met, for example low-balance alerts, spending limits, or operational thresholds.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create balance monitor](/reference/create-balance-monitor) | Attach a condition to a balance |
+| `get` | [Get balance monitor](/reference/get-balance-monitor) | Fetch one monitor by ID |
+| `list` | [Get balance monitor](/reference/get-balance-monitor) | List all monitors |
+| `update` | [Edit balance monitor](/reference/edit-balance-monitor) | Update monitor condition or balance |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Attach a condition to a balance. When the condition is met, Blnk sends a webhook.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.create({
+  balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  condition: {
+    field: 'credit_balance',
+    operator: '>',
+    value: 1000,
+    precision: 100,
+  },
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Create balance monitor](/reference/create-balance-monitor) and [Balance monitoring](/balances/balance-monitoring).
+
+---
+
+## `get`
+
+Fetch one monitor by ID.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.get(
+  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `list`
+
+Return all balance monitors.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.list();
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `update`
+
+Change the condition or target balance on an existing monitor.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.update(
+  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
+  {
+    balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+    condition: {
+      field: 'credit_balance',
+      operator: '<',
+      value: 500,
+      precision: 100,
+    },
+  },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Edit balance monitor](/reference/edit-balance-monitor).

--- a/sdks/typescript/balances.mdx
+++ b/sdks/typescript/balances.mdx
@@ -1,0 +1,72 @@
+---
+title: "Balances"
+sidebarTitle: "Balances"
+icon: "wallet"
+description: "Use the Blnk TypeScript SDK to create and retrieve ledger balances on your Core instance."
+"og:title": "Balances • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create and retrieve ledger balances on your Core instance."
+---
+
+Use `blnk.LedgerBalances` to open monetary accounts on a ledger and fetch balance records. Balances are the sources and destinations on transactions.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create balance](/reference/create-balance) | Open a balance on a ledger |
+| `get` | [Get balance](/reference/get-balance) | Fetch a balance by `balance_id` |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Create a balance on an existing ledger. Returns a `balance_id` you use as `source` or `destination` on transactions.
+
+See [Create balance](/reference/create-balance) for indicators, identity linking, and metadata.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.create({
+  ledger_id: 'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
+  currency: 'USD',
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.balance_id);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk balances create`. See [CLI balances](/cli/balances).
+</Tip>
+
+---
+
+## `get`
+
+Fetch one balance by ID, including credit/debit totals and currency.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.get(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | string | Yes | The balance ID (for example `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`). |
+
+<Tip>
+CLI equivalent: `blnk balances list --id <balance-id>`. See [CLI balances](/cli/balances).
+</Tip>
+
+See [Get balance](/reference/get-balance) for the full response shape. For concepts, see the [Balances guide](/balances/introduction).

--- a/sdks/typescript/identities.mdx
+++ b/sdks/typescript/identities.mdx
@@ -1,0 +1,105 @@
+---
+title: "Identities"
+sidebarTitle: "Identities"
+icon: "user"
+description: "Use the Blnk TypeScript SDK to create, retrieve, list, and update identities on your Core instance."
+"og:title": "Identities • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, list, and update identities on your Core instance."
+---
+
+Use `blnk.Identity` to register customers or organizations, link them to balances, and maintain profile data on your ledger.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create identity](/reference/create-identity) | Register a new identity |
+| `get` | [Get identity](/reference/get-identity) | Fetch one identity by `identity_id` |
+| `list` | [Get identity](/reference/get-identity) | List all identities |
+| `update` | [Edit identity](/reference/edit-identity) | Update identity fields |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Register an individual or organization identity. Use the returned `identity_id` when linking balances.
+
+See [Create identity](/reference/create-identity) for required fields by `identity_type`.
+
+```typescript wrap expandable
+const response = await blnk.Identity.create({
+  identity_type: 'individual',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  gender: 'female',
+  nationality: 'US',
+  dob: new Date('1990-01-15'),
+  email_address: 'jane@example.com',
+  phone_number: '+1234567890',
+  category: 'customer',
+  street: '123 Main St',
+  city: 'New York',
+  state: 'NY',
+  country: 'USA',
+  post_code: '10001',
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk identities create`. See [CLI identities](/cli/identities).
+</Tip>
+
+---
+
+## `get`
+
+Fetch one identity by ID.
+
+```typescript wrap
+const response = await blnk.Identity.get(
+  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `list`
+
+Return all identities on your Core instance.
+
+```typescript wrap
+const response = await blnk.Identity.list();
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `update`
+
+Update fields on an existing identity.
+
+```typescript wrap
+const response = await blnk.Identity.update(
+  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
+  { first_name: 'Jane', last_name: 'Smith' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Identities guide](/identities/introduction) for linking balances and PII tokenization.

--- a/sdks/typescript/ledgers.mdx
+++ b/sdks/typescript/ledgers.mdx
@@ -1,0 +1,72 @@
+---
+title: "Ledgers"
+sidebarTitle: "Ledgers"
+icon: "book-open"
+description: "Use the Blnk TypeScript SDK to create and retrieve ledgers on your Core instance."
+"og:title": "Ledgers • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create and retrieve ledgers on your Core instance."
+---
+
+Use `blnk.Ledgers` to create ledger containers and fetch ledger records. Ledgers group balances and transactions. Create one before opening balances on a book.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create ledger](/reference/create-ledger) | Create a new ledger |
+| `get` | [Get ledger](/reference/get-ledger) | Fetch a ledger by `ledger_id` |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Create a ledger container. You need a `ledger_id` from the response before creating balances.
+
+See [Create ledger](/reference/create-ledger) for all request fields.
+
+```typescript wrap
+const response = await blnk.Ledgers.create({
+  name: 'Customer accounts',
+  meta_data: { project_owner: 'MyApp' },
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.ledger_id);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk ledgers create`. See [CLI ledgers](/cli/ledgers).
+</Tip>
+
+---
+
+## `get`
+
+Fetch one ledger by ID, including its name and metadata.
+
+```typescript wrap
+const response = await blnk.Ledgers.get(
+  'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | string | Yes | The ledger ID (for example `ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb`). |
+
+<Tip>
+CLI equivalent: `blnk ledgers list --id <ledger-id>`. See [CLI ledgers](/cli/ledgers).
+</Tip>
+
+See [Get ledger](/reference/get-ledger) for the full response shape.

--- a/sdks/typescript/reconciliation.mdx
+++ b/sdks/typescript/reconciliation.mdx
@@ -1,0 +1,85 @@
+---
+title: "Reconciliation"
+sidebarTitle: "Reconciliation"
+icon: "scale"
+description: "Use the Blnk TypeScript SDK to upload external data, define matching rules, and run reconciliations."
+"og:title": "Reconciliation • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to upload external data, define matching rules, and run reconciliations."
+---
+
+Use `blnk.Reconciliation` to match external statements against ledger records. Upload a file, define how rows match transactions, then start a reconciliation run.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `upload` | [Upload data](/reference/upload-data) | Upload an external data file |
+| `createMatchingRule` | [Create matching rule](/reference/create-matching-rule) | Define how records match |
+| `run` | [Start reconciliation](/reference/start-reconciliation) | Run reconciliation against an upload |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `upload`
+
+Upload a CSV or other external data file for reconciliation. Pass a local file path and a source label.
+
+```typescript wrap
+const response = await blnk.Reconciliation.upload(
+  'statement.csv',
+  'stripe',
+);
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Upload data](/reference/upload-data) and the [Reconciliation overview](/reconciliations/overview).
+
+---
+
+## `createMatchingRule`
+
+Define criteria for matching uploaded rows to ledger transactions.
+
+```typescript wrap
+const response = await blnk.Reconciliation.createMatchingRule({
+  name: 'Amount match',
+  description: 'Match by amount',
+  criteria: [{ field: 'amount', operator: 'equals', allowable_drift: 0.01 }],
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Create matching rule](/reference/create-matching-rule) and [Matching rules](/reconciliations/matching-rules).
+
+---
+
+## `run`
+
+Start a reconciliation run against a previously uploaded file.
+
+```typescript wrap
+const response = await blnk.Reconciliation.run({
+  upload_id: 'upl_f3a8b2c1-9d4e-4a7b-8c6e-1f2d3e4a5b6c',
+  strategy: 'one_to_one',
+  dry_run: true,
+  grouping_criteria: 'amount',
+  matching_rule_ids: ['rule_abc123'],
+});
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk reconciliations`. See [CLI reconciliations](/cli/reconciliations).
+</Tip>
+
+See [Start reconciliation](/reference/start-reconciliation).

--- a/sdks/typescript/search.mdx
+++ b/sdks/typescript/search.mdx
@@ -1,0 +1,71 @@
+---
+title: "Search"
+sidebarTitle: "Search"
+icon: "search"
+description: "Use the Blnk TypeScript SDK to search ledgers, balances, and transactions via Typesense."
+"og:title": "Search • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to search ledgers, balances, and transactions via Typesense."
+---
+
+Use `blnk.Search` for full-text search powered by Typesense. Pass a query object and a collection name to search across ledgers, balances, or transactions.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `search` | [Search via Typesense](/reference/search-typesense) | Full-text search on a collection |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `search`
+
+Run a Typesense query against a collection. Pass `'ledgers'`, `'transactions'`, or `'balances'` as the second argument.
+
+```typescript wrap
+const response = await blnk.Search.search(
+  { q: 'payment', per_page: 20 },
+  'transactions',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `params` | object | Yes | Search query (for example `{ q: 'payment', per_page: 20 }`). |
+| `collection` | string | Yes | Collection name: `'ledgers'`, `'transactions'`, or `'balances'`. |
+
+<CodeGroup>
+```typescript Transactions wrap
+const response = await blnk.Search.search(
+  { q: 'payment', per_page: 20 },
+  'transactions',
+);
+```
+
+```typescript Balances wrap
+const response = await blnk.Search.search(
+  { q: 'USD', per_page: 20 },
+  'balances',
+);
+```
+
+```typescript Ledgers wrap
+const response = await blnk.Search.search(
+  { q: 'customer', per_page: 20 },
+  'ledgers',
+);
+```
+</CodeGroup>
+
+See [Search via Typesense](/reference/search-typesense) and the [Typesense introduction](/search/typesense/introduction).
+
+<Note>
+For structured DB queries without Typesense, use the [Search via DB](/reference/search-db) HTTP API directly. SDK support for DB filter and reindex is coming soon.
+</Note>

--- a/sdks/typescript/transactions.mdx
+++ b/sdks/typescript/transactions.mdx
@@ -1,0 +1,198 @@
+---
+title: "Transactions"
+sidebarTitle: "Transactions"
+icon: "arrow-left-right"
+description: "Use the Blnk TypeScript SDK to create, retrieve, update, and refund transactions on your Core instance."
+"og:title": "Transactions • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, update, and refund transactions on your Core instance."
+---
+
+Use `blnk.Transactions` to record transfers, submit bulk batches, manage inflight commits and voids, and refund applied posts. Reach for these methods when you are building payment flows, payroll, or any money movement in your application.
+
+Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
+
+| SDK method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create transaction](/reference/create-transaction) | Post a single transfer between balances |
+| `get` | [View transaction details](/reference/get-transaction) | Fetch one transaction by `transaction_id` |
+| `getByReference` | [Get transaction by reference](/reference/get-transaction-by-reference) | Fetch one transaction by your unique `reference` |
+| `createBulk` | [Bulk transactions](/reference/bulk-transactions) | Submit multiple transactions in one request |
+| `updateStatus` | [Update inflight](/reference/update-inflight) | Commit or void an inflight transaction |
+| `refund` | [Refund transaction](/reference/refund-transaction) | Reverse an applied transaction |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Post a transfer between a source and destination balance. Supports inflight, scheduling, split legs, and metadata.
+
+See [Create transaction](/reference/create-transaction) for all request fields, validation rules, and status behavior.
+
+```typescript wrap
+const response = await blnk.Transactions.create({
+  amount: 1000,
+  precision: 100,
+  currency: 'USD',
+  source: '@FundingPool',
+  destination: '@MyBalance',
+  reference: 'payment_001',
+  description: 'Customer payment',
+  allow_overdraft: true,
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id, response.data.status);
+}
+```
+
+---
+
+## `get`
+
+Inspect one transaction when you have its `transaction_id`, for example from a `create` response, refund output, or application logs.
+
+```typescript wrap
+const response = await blnk.Transactions.get(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id, response.data.status);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `transactionId` | string | Yes | The transaction ID (for example `txn_14706192-e53d-43cc-86a1-b8807a09b351`). |
+
+<Tip>
+CLI equivalent: `blnk transactions list --id <transaction-id>`. See [CLI transactions](/cli/transactions).
+</Tip>
+
+See [View transaction details](/reference/get-transaction) for the full response shape.
+
+---
+
+## `getByReference`
+
+Look up a transaction using the unique `reference` your application supplied at create time. Use this for idempotency checks, support tooling, or reconciliation when you store references but not Blnk IDs.
+
+The SDK URL-encodes the reference in the request path.
+
+```typescript wrap
+const response = await blnk.Transactions.getByReference('payment_001');
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id, response.data.reference);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `reference` | string | Yes | The unique reference passed when the transaction was created. |
+
+See [Get transaction by reference](/reference/get-transaction-by-reference) for the full response shape.
+
+---
+
+## `createBulk`
+
+Submit multiple transaction records in one request. Use `atomic: true` when every leg must succeed or fail together.
+
+Do not set `status` on bulk create requests. Core manages status during processing.
+
+For concepts and options (`inflight`, `run_async`, `skip_queue`), see the [Bulk transactions guide](/transactions/bulk-transactions).
+
+```typescript wrap expandable
+const response = await blnk.Transactions.createBulk({
+  atomic: true,
+  transactions: [
+    {
+      amount: 1000,
+      precision: 100,
+      currency: 'USD',
+      source: '@source_1',
+      destination: '@dest_1',
+      reference: 'bulk_001',
+      description: 'Payment 1',
+    },
+    {
+      amount: 2000,
+      precision: 100,
+      currency: 'USD',
+      source: '@source_2',
+      destination: '@dest_2',
+      reference: 'bulk_002',
+      description: 'Payment 2',
+    },
+  ],
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.batch_id, response.data.status);
+}
+```
+
+See [Bulk transactions](/reference/bulk-transactions) for request and response fields.
+
+---
+
+## `updateStatus`
+
+Commit or void an inflight transaction. Pass `status: 'commit'` to apply funds, or `status: 'void'` to cancel.
+
+```typescript wrap
+const response = await blnk.Transactions.updateStatus(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+  { status: 'commit' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+For partial commits, include `amount` or `precise_amount`. See [Update inflight](/reference/update-inflight) and the [Inflight guide](/transactions/inflight).
+
+---
+
+## `refund`
+
+Reverse an applied transaction. Blnk creates a new transaction that swaps source and destination.
+
+```typescript wrap
+const response = await blnk.Transactions.refund(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+);
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+Pass an optional body to process synchronously:
+
+```typescript wrap
+const response = await blnk.Transactions.refund(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+  { skip_queue: true },
+);
+```
+
+See [Refund transaction](/reference/refund-transaction) and the [Refunds guide](/transactions/refunds).


### PR DESCRIPTION
## Summary
- Split TypeScript SDK docs into dedicated **Resource methods** sidebar pages (ledgers, balances, transactions, identities, reconciliation, search, balance monitors)
- Slim the install hub: remove the tabbed endpoint map and SDK resources card grid (sidebar is the navigation)
- Add **Verify connectivity** Quick start step using `blnk.System.health()`
- No separate System sidebar page; health links to the Core [Health check](/reference/get-health) reference

## Test plan
- [x] Install page flow reviewed: Launch Blnk → Install SDK → Client init → Verify connectivity → First transaction
- [x] `blnk-ts` unit tests re-run for shipped method examples (314 passing)
- [ ] `npx mintlify dev` in `blnk-docs` and spot-check sidebar + transactions page