### PR TITLE
docs(typescript): expand SDK resource pages and search/reconciliation coverage

### DIFF
--- a/cli/ledgers.mdx
+++ b/cli/ledgers.mdx
@@ -7,7 +7,7 @@ description: "Use the Blnk CLI to list and create ledgers on your Core instance.
 "og:description": "Use the Blnk CLI to list and create ledgers on your Core instance."
 ---
 
-Use the `ledgers` command to browse ledger containers, open one record by ID, and create new ledgers on your connected Core instance. Ledgers group balances and transactions; start here when you need a `ledger_id` for balance setup.
+Use the `ledgers` command to browse ledgers, open one record by ID, and create new ledgers on your connected Core instance. Ledgers group balances and transactions; start here when you need a `ledger_id` for balance setup.
 
 | Command | Alias | Description |
 | :--- | :--- | :--- |
@@ -121,7 +121,7 @@ Ledger details:
 
 ## `create`
 
-Add a ledger container through guided prompts for name and optional JSON metadata.
+Add a ledger through guided prompts for name and optional JSON metadata.
 
 Create ledgers first when you are standing up a new product, region, or currency scope. Balances and transactions hang off a ledger.
 

--- a/docs.json
+++ b/docs.json
@@ -679,6 +679,18 @@
                   "sdks/typescript",
                   "changelog/blnk-ts"
                 ]
+              },
+              {
+                "group": "Resource methods",
+                "pages": [
+                  "sdks/typescript/ledgers",
+                  "sdks/typescript/balances",
+                  "sdks/typescript/transactions",
+                  "sdks/typescript/identities",
+                  "sdks/typescript/reconciliation",
+                  "sdks/typescript/search",
+                  "sdks/typescript/balance-monitors"
+                ]
               }
             ]
           },

--- a/sdks/typescript.mdx
+++ b/sdks/typescript.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started with the TypeScript SDK"
 description: "Install the Blnk TypeScript SDK, run your first transaction, and find the Core docs for every SDK method."
-sidebarTitle: "TypeScript"
+sidebarTitle: "Install"
 icon: "code"
 "og:title": "Getting Started with the TypeScript SDK • Blnk SDK Documentation"
 "og:description": "Install the Blnk TypeScript SDK, initialize the client, and record your first transaction in TypeScript."
@@ -56,6 +56,25 @@ const blnk = BlnkInit(apiKey, {
   timeout: 10000,
 });
 ```
+
+</Step>
+
+<Step title="Verify connectivity">
+
+Confirm Core is reachable before you post a transaction. The health endpoint does not require authentication on local instances.
+
+```typescript wrap
+const health = await blnk.System.health();
+
+if (health.status !== 200 || health.data?.status !== 'UP') {
+  console.error('Core is not reachable:', health.message);
+  process.exit(1);
+}
+
+console.log('Core status:', health.data.status);
+```
+
+See [Health check](/reference/get-health) for deployment and probe notes.
 
 </Step>
 
@@ -156,8 +175,9 @@ Reference the Core documentation to understand how each API works. This section 
 - `blnk.Reconciliation`
 - `blnk.Search`
 - `blnk.Identity`
+- `blnk.System`
 
-Call methods on the service that matches the resource you need. The [endpoint map](#endpoint-map) lists each method and links to its API reference page.
+Call methods on the service that matches the resource you need. Browse [**Resource methods**](/sdks/typescript/transactions) in the sidebar for method-level examples and Core API links.
 
 ### Request field names
 
@@ -203,299 +223,6 @@ CommonJS also works and matches the [GitHub examples](https://github.com/blnkfin
 ```javascript wrap
 const { BlnkInit } = require('@blnkfinance/blnk-typescript');
 ```
-
----
-
-## Endpoint map
-
-Each SDK method calls a Blnk Core HTTP endpoint. Use this map to find the SDK method for an operation and open its reference page for field definitions and business logic.
-
-<Tip>
-Read the linked Core reference page for each method to understand required fields, validation rules, and behavior.
-</Tip>
-
-<Tabs>
-<Tab title="Ledgers">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Ledgers.create` | [Create ledger](/reference/create-ledger) |
-| `blnk.Ledgers.get` | [Get ledger](/reference/get-ledger) |
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.Ledgers.create({
-  name: 'Customer accounts',
-  meta_data: { project_owner: 'MyApp' },
-});
-```
-
-```typescript Get wrap
-const response = await blnk.Ledgers.get(
-  'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Balances">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.LedgerBalances.create` | [Create balance](/reference/create-balance) |
-| `blnk.LedgerBalances.get` | [Get balance](/reference/get-balance) |
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.LedgerBalances.create({
-  ledger_id: 'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
-  currency: 'USD',
-});
-```
-
-```typescript Get wrap
-const response = await blnk.LedgerBalances.get(
-  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Transactions">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Transactions.create` | [Create transaction](/reference/create-transaction) |
-| `blnk.Transactions.createBulk` | [Bulk transactions](/reference/bulk-transactions) |
-| `blnk.Transactions.updateStatus` | [Update inflight](/reference/update-inflight) |
-| `blnk.Transactions.refund` | [Refund transaction](/reference/refund-transaction) |
-
-For bulk transaction concepts and options, see the [Bulk transactions guide](/transactions/bulk-transactions).
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.Transactions.create({
-  amount: 1000,
-  precision: 100,
-  currency: 'USD',
-  source: '@FundingPool',
-  destination: '@MyBalance',
-  reference: 'payment_001',
-  allow_overdraft: true,
-});
-```
-
-```typescript CreateBulk wrap expandable
-const response = await blnk.Transactions.createBulk({
-  atomic: true,
-  transactions: [
-    {
-      amount: 1000,
-      precision: 100,
-      currency: 'USD',
-      source: '@source_1',
-      destination: '@dest_1',
-      reference: 'bulk_001',
-      description: 'Payment 1',
-    },
-    {
-      amount: 2000,
-      precision: 100,
-      currency: 'USD',
-      source: '@source_2',
-      destination: '@dest_2',
-      reference: 'bulk_002',
-      description: 'Payment 2',
-    },
-  ],
-});
-```
-
-```typescript UpdateStatus wrap
-const response = await blnk.Transactions.updateStatus(
-  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
-  { status: 'commit' },
-);
-```
-
-```typescript Refund wrap
-const response = await blnk.Transactions.refund(
-  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Reconciliation">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Reconciliation.upload` | [Upload data](/reference/upload-data) |
-| `blnk.Reconciliation.createMatchingRule` | [Create matching rule](/reference/create-matching-rule) |
-| `blnk.Reconciliation.run` | [Start reconciliation](/reference/start-reconciliation) |
-
-<CodeGroup>
-```typescript Upload wrap
-const response = await blnk.Reconciliation.upload(
-  'statement.csv',
-  'stripe',
-);
-```
-
-```typescript CreateMatchingRule wrap
-const response = await blnk.Reconciliation.createMatchingRule({
-  name: 'Amount match',
-  description: 'Match by amount',
-  criteria: [{ field: 'amount', operator: 'equals', allowable_drift: 0.01 }],
-});
-```
-
-```typescript Run wrap
-const response = await blnk.Reconciliation.run({
-  upload_id: 'upl_f3a8b2c1-9d4e-4a7b-8c6e-1f2d3e4a5b6c',
-  strategy: 'one_to_one',
-  dry_run: true,
-  grouping_criteria: 'amount',
-  matching_rule_ids: ['rule_abc123'],
-});
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Identities">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Identity.create` | [Create identity](/reference/create-identity) |
-| `blnk.Identity.get` | [Get identity](/reference/get-identity) |
-| `blnk.Identity.list` | [Get identity](/reference/get-identity) |
-| `blnk.Identity.update` | [Edit identity](/reference/edit-identity) |
-
-<CodeGroup>
-```typescript Create wrap expandable
-const response = await blnk.Identity.create({
-  identity_type: 'individual',
-  first_name: 'Jane',
-  last_name: 'Doe',
-  gender: 'female',
-  nationality: 'US',
-  dob: new Date('1990-01-15'),
-  email_address: 'jane@example.com',
-  phone_number: '+1234567890',
-  category: 'customer',
-  street: '123 Main St',
-  city: 'New York',
-  state: 'NY',
-  country: 'USA',
-  post_code: '10001',
-});
-```
-
-```typescript Get wrap
-const response = await blnk.Identity.get(
-  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
-);
-```
-
-```typescript List wrap
-const response = await blnk.Identity.list();
-```
-
-```typescript Update wrap
-const response = await blnk.Identity.update(
-  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
-  { first_name: 'Jane', last_name: 'Smith' },
-);
-```
-</CodeGroup>
-
-</Tab>
-<Tab title="Typesense Search">
-
-Use `Search.search` for full-text search powered by Typesense.
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.Search.search(params, collection)` | [Search via Typesense](/reference/search-typesense) |
-
-Pass a collection name as the second argument: `'ledgers'`, `'transactions'`, or `'balances'`.
-
-<CodeGroup>
-```typescript Transactions wrap
-const response = await blnk.Search.search(
-  { q: 'payment', per_page: 20 },
-  'transactions',
-);
-```
-
-```typescript Balances wrap
-const response = await blnk.Search.search(
-  { q: 'USD', per_page: 20 },
-  'balances',
-);
-```
-
-```typescript Ledgers wrap
-const response = await blnk.Search.search(
-  { q: 'customer', per_page: 20 },
-  'ledgers',
-);
-```
-</CodeGroup>
-
-For structured DB queries without Typesense, use the [Search via DB](/reference/search-db) HTTP API directly.
-
-</Tab>
-<Tab title="Monitors">
-
-| SDK method | API Reference |
-|------------|---------------|
-| `blnk.BalanceMonitor.create` | [Create balance monitor](/reference/create-balance-monitor) |
-| `blnk.BalanceMonitor.get` | [Get balance monitor](/reference/get-balance-monitor) |
-| `blnk.BalanceMonitor.list` | [Get balance monitor](/reference/get-balance-monitor) |
-| `blnk.BalanceMonitor.update` | [Edit balance monitor](/reference/edit-balance-monitor) |
-
-<CodeGroup>
-```typescript Create wrap
-const response = await blnk.BalanceMonitor.create({
-  balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-  condition: {
-    field: 'credit_balance',
-    operator: '>',
-    value: 1000,
-    precision: 100,
-  },
-});
-```
-
-```typescript Get wrap
-const response = await blnk.BalanceMonitor.get(
-  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
-);
-```
-
-```typescript List wrap
-const response = await blnk.BalanceMonitor.list();
-```
-
-```typescript Update wrap
-const response = await blnk.BalanceMonitor.update(
-  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
-  {
-    balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-    condition: {
-      field: 'credit_balance',
-      operator: '<',
-      value: 500,
-      precision: 100,
-    },
-  },
-);
-```
-</CodeGroup>
-
-</Tab>
-</Tabs>
 
 ---
 

--- a/sdks/typescript/balance-monitors.mdx
+++ b/sdks/typescript/balance-monitors.mdx
@@ -1,0 +1,102 @@
+---
+title: "Balance monitors"
+sidebarTitle: "Balance monitors"
+icon: "bell"
+description: "Use the Blnk TypeScript SDK to create and manage balance monitors on your Core instance."
+"og:title": "Balance monitors • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create and manage balance monitors on your Core instance."
+---
+
+Use `blnk.BalanceMonitor` to watch balance levels and trigger webhooks when conditions are met, for example low-balance alerts, spending limits, or operational thresholds.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create balance monitor](/reference/create-balance-monitor) | Attach a condition to a balance |
+| `get` | [Get balance monitor](/reference/get-balance-monitor) | Fetch one monitor by ID |
+| `list` | [Get balance monitor](/reference/get-balance-monitor) | List all monitors |
+| `update` | [Edit balance monitor](/reference/edit-balance-monitor) | Update monitor condition or balance |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Attach a condition to a balance. When the condition is met, Blnk sends a webhook.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.create({
+  balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  condition: {
+    field: 'credit_balance',
+    operator: '>',
+    value: 1000,
+    precision: 100,
+  },
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Create balance monitor](/reference/create-balance-monitor) and [Balance monitoring](/balances/balance-monitoring).
+
+---
+
+## `get`
+
+Fetch one monitor by ID.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.get(
+  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `list`
+
+Return all balance monitors.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.list();
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `update`
+
+Change the condition or target balance on an existing monitor.
+
+```typescript wrap
+const response = await blnk.BalanceMonitor.update(
+  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
+  {
+    balance_id: 'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+    condition: {
+      field: 'credit_balance',
+      operator: '<',
+      value: 500,
+      precision: 100,
+    },
+  },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Edit balance monitor](/reference/edit-balance-monitor).

--- a/sdks/typescript/balance-monitors.mdx
+++ b/sdks/typescript/balance-monitors.mdx
@@ -7,14 +7,11 @@ description: "Use the Blnk TypeScript SDK to create and manage balance monitors 
 "og:description": "Use the Blnk TypeScript SDK to create and manage balance monitors on your Core instance."
 ---
 
+## Overview
+
 Use `blnk.BalanceMonitor` to watch balance levels and trigger webhooks when conditions are met, for example low-balance alerts, spending limits, or operational thresholds.
 
-| Method | API Reference | Description |
-| :--- | :--- | :--- |
-| `create` | [Create balance monitor](/reference/create-balance-monitor) | Attach a condition to a balance |
-| `get` | [Get balance monitor](/reference/get-balance-monitor) | Fetch one monitor by ID |
-| `list` | [Get balance monitor](/reference/get-balance-monitor) | List all monitors |
-| `update` | [Edit balance monitor](/reference/edit-balance-monitor) | Update monitor condition or balance |
+For setup and webhook behavior, see [Balance monitoring](/balances/balance-monitoring).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -22,9 +19,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `create`
+## Create a balance monitor
 
-Attach a condition to a balance. When the condition is met, Blnk sends a webhook.
+`blnk.BalanceMonitor.create` attaches a condition to a balance. When the condition is met, Blnk sends a webhook.
 
 ```typescript wrap
 const response = await blnk.BalanceMonitor.create({
@@ -42,13 +39,15 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Create balance monitor](/reference/create-balance-monitor) for all request fields and the response, and [Balance monitoring](/balances/balance-monitoring) for setup and concepts.
+For setup and concepts, see [Balance monitoring](/balances/balance-monitoring).
+
+See [Create balance monitor](/reference/create-balance-monitor) for request fields, response shape, and validation.
 
 ---
 
-## `get`
+## Get a balance monitor
 
-Fetch one monitor by ID.
+`blnk.BalanceMonitor.get` fetches one monitor by ID.
 
 ```typescript wrap
 const response = await blnk.BalanceMonitor.get(
@@ -60,13 +59,13 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Get balance monitor](/reference/get-balance-monitor) for all response fields.
+See [Get balance monitor](/reference/get-balance-monitor) for request fields, response shape, and validation.
 
 ---
 
-## `list`
+## List balance monitors
 
-Return all balance monitors.
+`blnk.BalanceMonitor.list` returns all balance monitors.
 
 ```typescript wrap
 const response = await blnk.BalanceMonitor.list();
@@ -76,13 +75,13 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Get balance monitor](/reference/get-balance-monitor) for all response fields.
+See [Get balance monitor](/reference/get-balance-monitor) for request fields, response shape, and validation.
 
 ---
 
-## `update`
+## Update a balance monitor
 
-Change the condition or target balance on an existing monitor.
+`blnk.BalanceMonitor.update` changes the condition or target balance on an existing monitor.
 
 ```typescript wrap
 const response = await blnk.BalanceMonitor.update(
@@ -103,4 +102,26 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Edit balance monitor](/reference/edit-balance-monitor) for all request fields and the response.
+See [Edit balance monitor](/reference/edit-balance-monitor) for request fields, response shape, and validation.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Balances" icon="wallet" href="/sdks/typescript/balances">
+Create and inspect the balances you monitor.
+</Card>
+
+<Card title="Balance monitoring" icon="bell" href="/balances/balance-monitoring">
+Webhook setup and condition fields.
+</Card>
+
+<Card title="Webhooks" icon="webhook" href="/watch/webhooks">
+Receive monitor events in your app.
+</Card>
+
+<Card title="Transactions" icon="arrow-left-right" href="/sdks/typescript/transactions">
+Move funds that trigger balance changes.
+</Card>
+</CardGroup>

--- a/sdks/typescript/balance-monitors.mdx
+++ b/sdks/typescript/balance-monitors.mdx
@@ -42,7 +42,7 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Create balance monitor](/reference/create-balance-monitor) and [Balance monitoring](/balances/balance-monitoring).
+See [Create balance monitor](/reference/create-balance-monitor) for all request fields and the response, and [Balance monitoring](/balances/balance-monitoring) for setup and concepts.
 
 ---
 
@@ -60,6 +60,8 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
+See [Get balance monitor](/reference/get-balance-monitor) for all response fields.
+
 ---
 
 ## `list`
@@ -73,6 +75,8 @@ if (response.status !== 200 || !response.data) {
   console.error(`Error ${response.status}: ${response.message}`);
 }
 ```
+
+See [Get balance monitor](/reference/get-balance-monitor) for all response fields.
 
 ---
 
@@ -99,4 +103,4 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Edit balance monitor](/reference/edit-balance-monitor).
+See [Edit balance monitor](/reference/edit-balance-monitor) for all request fields and the response.

--- a/sdks/typescript/balances.mdx
+++ b/sdks/typescript/balances.mdx
@@ -31,7 +31,7 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 Create a balance on an existing ledger. Returns a `balance_id` you use as `source` or `destination` on transactions.
 
-See [Create balance](/reference/create-balance) for indicators, identity linking, fund lineage, and metadata.
+See [Create balance](/reference/create-balance) for all request fields and the response.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.create({
@@ -68,7 +68,7 @@ CLI equivalent: `blnk balances create`. See [CLI balances](/cli/balances).
 
 Fetch one balance by ID, including credit/debit totals and currency. Pass `{ from_source: true }` to reconstruct the balance from transactions instead of snapshots.
 
-See [Get balance](/reference/get-balance) and [Balance from source](/reference/balance-from-source) for response shapes.
+See [Get balance](/reference/get-balance) and [Balance from source](/reference/balance-from-source) for query parameters and response fields.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.get(
@@ -123,7 +123,7 @@ if (response.status !== 200 || !response.data) {
 | `indicator` | string | Yes | The balance indicator (for example `@World`). |
 | `currency` | string | Yes | The currency code (for example `USD`). |
 
-See [Get balance by indicator](/reference/get-balance-by-indicator) for the full response shape.
+See [Get balance by indicator](/reference/get-balance-by-indicator) for all response fields.
 
 ---
 
@@ -151,7 +151,7 @@ if (response.status !== 200 || !response.data) {
 | `balanceId` | string | Yes | The balance ID to update. |
 | `data.identity_id` | string | Yes | The identity ID to link. |
 
-See [Update balance identity](/reference/update-balance-identity) for the full response shape.
+See [Update balance identity](/reference/update-balance-identity) for all request fields and the response.
 
 ---
 
@@ -175,7 +175,7 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `options.batch_size` | number | No | Balances processed per batch. Positive values are sent as a query param; omit or pass `0` for the server default. |
 
-See [Balance snapshots](/reference/balances-snapshots) for operational notes.
+See [Balance snapshots](/reference/balances-snapshots) for query parameters and the response.
 
 ---
 
@@ -211,7 +211,7 @@ const response = await blnk.LedgerBalances.getAt(
 | `options.timestamp` | string | Yes | ISO 8601 timestamp (for example `2025-02-24T08:55:26Z`). |
 | `options.from_source` | boolean | No | When `true`, reconstruct from transactions instead of snapshots. |
 
-See [Historical balances](/reference/historical-balances) and the [Historical balances guide](/balances/historical-balances).
+See [Historical balances](/reference/historical-balances) for query parameters and response fields, and the [Historical balances guide](/balances/historical-balances) for concepts.
 
 ---
 
@@ -237,4 +237,4 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `balanceId` | string | Yes | The balance ID with fund lineage enabled. |
 
-See [View balance lineage](/reference/get-balance-lineage) for the full response shape.
+See [View balance lineage](/reference/get-balance-lineage) for all response fields.

--- a/sdks/typescript/balances.mdx
+++ b/sdks/typescript/balances.mdx
@@ -2,17 +2,24 @@
 title: "Balances"
 sidebarTitle: "Balances"
 icon: "wallet"
-description: "Use the Blnk TypeScript SDK to create and retrieve ledger balances on your Core instance."
+description: "Use the Blnk TypeScript SDK to create, retrieve, and manage ledger balances on your Core instance."
 "og:title": "Balances • Blnk TypeScript SDK"
-"og:description": "Use the Blnk TypeScript SDK to create and retrieve ledger balances on your Core instance."
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, and manage ledger balances on your Core instance."
 ---
 
-Use `blnk.LedgerBalances` to open monetary accounts on a ledger and fetch balance records. Balances are the sources and destinations on transactions.
+Use `blnk.LedgerBalances` to open monetary accounts on a ledger, look them up by ID or indicator, link identities, trigger snapshots, and inspect historical or lineage-tracked funds. Balances are the sources and destinations on transactions.
+
+Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
 
 | Method | API Reference | Description |
 | :--- | :--- | :--- |
 | `create` | [Create balance](/reference/create-balance) | Open a balance on a ledger |
 | `get` | [Get balance](/reference/get-balance) | Fetch a balance by `balance_id` |
+| `getByIndicator` | [Get balance by indicator](/reference/get-balance-by-indicator) | Fetch a balance by indicator and currency |
+| `updateIdentity` | [Update balance identity](/reference/update-balance-identity) | Link a balance to an identity |
+| `createSnapshot` | [Balance snapshots](/reference/balances-snapshots) | Trigger daily balance snapshots in batches |
+| `getAt` | [Historical balances](/reference/historical-balances) | Fetch a balance at a specific timestamp |
+| `getLineage` | [View balance lineage](/reference/get-balance-lineage) | Fetch provider breakdown when fund lineage is enabled |
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -24,7 +31,7 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 Create a balance on an existing ledger. Returns a `balance_id` you use as `source` or `destination` on transactions.
 
-See [Create balance](/reference/create-balance) for indicators, identity linking, and metadata.
+See [Create balance](/reference/create-balance) for indicators, identity linking, fund lineage, and metadata.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.create({
@@ -39,6 +46,18 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
+To enable [fund lineage tracking](/transactions/lineage), pass `identity_id`, `track_fund_lineage: true`, and an optional `allocation_strategy` (`FIFO`, `LIFO`, or `PROPORTIONAL`):
+
+```typescript wrap
+const response = await blnk.LedgerBalances.create({
+  ledger_id: 'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
+  identity_id: 'idt_3b63c8da-af29-4cc3-ad38-df17d87456e6',
+  currency: 'USD',
+  track_fund_lineage: true,
+  allocation_strategy: 'FIFO',
+});
+```
+
 <Tip>
 CLI equivalent: `blnk balances create`. See [CLI balances](/cli/balances).
 </Tip>
@@ -47,7 +66,9 @@ CLI equivalent: `blnk balances create`. See [CLI balances](/cli/balances).
 
 ## `get`
 
-Fetch one balance by ID, including credit/debit totals and currency.
+Fetch one balance by ID, including credit/debit totals and currency. Pass `{ from_source: true }` to reconstruct the balance from transactions instead of snapshots.
+
+See [Get balance](/reference/get-balance) and [Balance from source](/reference/balance-from-source) for response shapes.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.get(
@@ -59,14 +80,161 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
+```typescript wrap
+const response = await blnk.LedgerBalances.get(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { from_source: true },
+);
+```
+
 <Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
 
 | Parameter | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `id` | string | Yes | The balance ID (for example `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`). |
+| `options.from_source` | boolean | No | When `true`, reconstruct the balance from transactions instead of snapshots. |
 
 <Tip>
 CLI equivalent: `blnk balances list --id <balance-id>`. See [CLI balances](/cli/balances).
 </Tip>
 
-See [Get balance](/reference/get-balance) for the full response shape. For concepts, see the [Balances guide](/balances/introduction).
+For concepts, see the [Balances guide](/balances/introduction).
+
+---
+
+## `getByIndicator`
+
+Look up a balance using its indicator and currency, for example `@World` and `USD`. The SDK URL-encodes the indicator in the request path.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.getByIndicator('@World', 'USD');
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.balance_id, response.data.indicator);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `indicator` | string | Yes | The balance indicator (for example `@World`). |
+| `currency` | string | Yes | The currency code (for example `USD`). |
+
+See [Get balance by indicator](/reference/get-balance-by-indicator) for the full response shape.
+
+---
+
+## `updateIdentity`
+
+Link a balance to an identity. Required before enabling fund lineage on balances that were created without an `identity_id`.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.updateIdentity(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { identity_id: 'idt_3b63c8da-af29-4cc3-ad38-df17d87456e6' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.message);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `balanceId` | string | Yes | The balance ID to update. |
+| `data.identity_id` | string | Yes | The identity ID to link. |
+
+See [Update balance identity](/reference/update-balance-identity) for the full response shape.
+
+---
+
+## `createSnapshot`
+
+Trigger daily balance snapshots in batches. Omit `batch_size` or pass `0` to use the server default (1000).
+
+```typescript wrap
+const response = await blnk.LedgerBalances.createSnapshot({ batch_size: 500 });
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.message);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `options.batch_size` | number | No | Balances processed per batch. Positive values are sent as a query param; omit or pass `0` for the server default. |
+
+See [Balance snapshots](/reference/balances-snapshots) for operational notes.
+
+---
+
+## `getAt`
+
+Retrieve a balance at a specific point in time. Pass an ISO 8601 timestamp (RFC3339). Set `from_source: true` to reconstruct from transactions instead of snapshots.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.getAt(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { timestamp: '2025-02-24T08:55:26Z' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.balance.balance, response.data.timestamp);
+}
+```
+
+```typescript wrap
+const response = await blnk.LedgerBalances.getAt(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { timestamp: '2025-02-24T08:55:26Z', from_source: true },
+);
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `balanceId` | string | Yes | The balance ID to query. |
+| `options.timestamp` | string | Yes | ISO 8601 timestamp (for example `2025-02-24T08:55:26Z`). |
+| `options.from_source` | boolean | No | When `true`, reconstruct from transactions instead of snapshots. |
+
+See [Historical balances](/reference/historical-balances) and the [Historical balances guide](/balances/historical-balances).
+
+---
+
+## `getLineage`
+
+Inspect provider-level fund breakdown for a balance with [fund lineage](/transactions/lineage) enabled. Returns received, spent, and available amounts per provider in minor units.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.getLineage(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.total_with_lineage, response.data.providers.length);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `balanceId` | string | Yes | The balance ID with fund lineage enabled. |
+
+See [View balance lineage](/reference/get-balance-lineage) for the full response shape.

--- a/sdks/typescript/balances.mdx
+++ b/sdks/typescript/balances.mdx
@@ -1,0 +1,72 @@
+---
+title: "Balances"
+sidebarTitle: "Balances"
+icon: "wallet"
+description: "Use the Blnk TypeScript SDK to create and retrieve ledger balances on your Core instance."
+"og:title": "Balances • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create and retrieve ledger balances on your Core instance."
+---
+
+Use `blnk.LedgerBalances` to open monetary accounts on a ledger and fetch balance records. Balances are the sources and destinations on transactions.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create balance](/reference/create-balance) | Open a balance on a ledger |
+| `get` | [Get balance](/reference/get-balance) | Fetch a balance by `balance_id` |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Create a balance on an existing ledger. Returns a `balance_id` you use as `source` or `destination` on transactions.
+
+See [Create balance](/reference/create-balance) for indicators, identity linking, and metadata.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.create({
+  ledger_id: 'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
+  currency: 'USD',
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.balance_id);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk balances create`. See [CLI balances](/cli/balances).
+</Tip>
+
+---
+
+## `get`
+
+Fetch one balance by ID, including credit/debit totals and currency.
+
+```typescript wrap
+const response = await blnk.LedgerBalances.get(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | string | Yes | The balance ID (for example `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`). |
+
+<Tip>
+CLI equivalent: `blnk balances list --id <balance-id>`. See [CLI balances](/cli/balances).
+</Tip>
+
+See [Get balance](/reference/get-balance) for the full response shape. For concepts, see the [Balances guide](/balances/introduction).

--- a/sdks/typescript/balances.mdx
+++ b/sdks/typescript/balances.mdx
@@ -175,7 +175,7 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `options.batch_size` | number | No | Balances processed per batch. Positive values are sent as a query param; omit or pass `0` for the server default. |
 
-See [Balance snapshots](/reference/balances-snapshots) for query parameters and the response.
+See [Balance snapshots](/reference/balances-snapshots) for query parameters and the response, and the [Balance snapshots guide](/balances/balance-snapshots) for setup and concepts.
 
 ---
 
@@ -237,4 +237,4 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `balanceId` | string | Yes | The balance ID with fund lineage enabled. |
 
-See [View balance lineage](/reference/get-balance-lineage) for all response fields.
+See [View balance lineage](/reference/get-balance-lineage) for all response fields, and the [Fund lineage guide](/transactions/lineage) for setup and concepts.

--- a/sdks/typescript/balances.mdx
+++ b/sdks/typescript/balances.mdx
@@ -7,19 +7,11 @@ description: "Use the Blnk TypeScript SDK to create, retrieve, and manage ledger
 "og:description": "Use the Blnk TypeScript SDK to create, retrieve, and manage ledger balances on your Core instance."
 ---
 
-Use `blnk.LedgerBalances` to open monetary accounts on a ledger, look them up by ID or indicator, link identities, trigger snapshots, and inspect historical or lineage-tracked funds. Balances are the sources and destinations on transactions.
+## Overview
 
-Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
+Use `blnk.LedgerBalances` to create accounts on a ledger, fetch them by ID or indicator, link identities, trigger snapshots, and inspect historical or lineage-tracked funds. Balances are the sources and destinations on transactions.
 
-| Method | API Reference | Description |
-| :--- | :--- | :--- |
-| `create` | [Create balance](/reference/create-balance) | Open a balance on a ledger |
-| `get` | [Get balance](/reference/get-balance) | Fetch a balance by `balance_id` |
-| `getByIndicator` | [Get balance by indicator](/reference/get-balance-by-indicator) | Fetch a balance by indicator and currency |
-| `updateIdentity` | [Update balance identity](/reference/update-balance-identity) | Link a balance to an identity |
-| `createSnapshot` | [Balance snapshots](/reference/balances-snapshots) | Trigger daily balance snapshots in batches |
-| `getAt` | [Historical balances](/reference/historical-balances) | Fetch a balance at a specific timestamp |
-| `getLineage` | [View balance lineage](/reference/get-balance-lineage) | Fetch provider breakdown when fund lineage is enabled |
+For concepts and setup, see the [Balances guide](/balances/introduction).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -27,11 +19,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `create`
+## Create a balance
 
-Create a balance on an existing ledger. Returns a `balance_id` you use as `source` or `destination` on transactions.
-
-See [Create balance](/reference/create-balance) for all request fields and the response.
+`blnk.LedgerBalances.create` creates a balance on an existing ledger. Returns a `balance_id` you use as `source` or `destination` on transactions.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.create({
@@ -62,13 +52,13 @@ const response = await blnk.LedgerBalances.create({
 CLI equivalent: `blnk balances create`. See [CLI balances](/cli/balances).
 </Tip>
 
+See [Create balance](/reference/create-balance) for request fields, response shape, and validation.
+
 ---
 
-## `get`
+## Get a balance
 
-Fetch one balance by ID, including credit/debit totals and currency. Pass `{ from_source: true }` to reconstruct the balance from transactions instead of snapshots.
-
-See [Get balance](/reference/get-balance) and [Balance from source](/reference/balance-from-source) for query parameters and response fields.
+`blnk.LedgerBalances.get` fetches one balance by ID, including credit/debit totals and currency. Pass `{ from_source: true }` to reconstruct the balance from transactions instead of snapshots.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.get(
@@ -100,11 +90,13 @@ CLI equivalent: `blnk balances list --id <balance-id>`. See [CLI balances](/cli/
 
 For concepts, see the [Balances guide](/balances/introduction).
 
+See [Get balance](/reference/get-balance) for request fields and response shape. For `from_source` queries, see [Balance from source](/reference/balance-from-source).
+
 ---
 
-## `getByIndicator`
+## Get a balance by indicator
 
-Look up a balance using its indicator and currency, for example `@World` and `USD`. The SDK URL-encodes the indicator in the request path.
+`blnk.LedgerBalances.getByIndicator` looks up a balance using its indicator and currency, for example `@World` and `USD`. The SDK URL-encodes the indicator in the request path.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.getByIndicator('@World', 'USD');
@@ -123,13 +115,13 @@ if (response.status !== 200 || !response.data) {
 | `indicator` | string | Yes | The balance indicator (for example `@World`). |
 | `currency` | string | Yes | The currency code (for example `USD`). |
 
-See [Get balance by indicator](/reference/get-balance-by-indicator) for all response fields.
+See [Get balance by indicator](/reference/get-balance-by-indicator) for request fields, response shape, and validation.
 
 ---
 
-## `updateIdentity`
+## Link a balance to an identity
 
-Link a balance to an identity. Required before enabling fund lineage on balances that were created without an `identity_id`.
+`blnk.LedgerBalances.updateIdentity` links a balance to an identity. Required before enabling fund lineage on balances that were created without an `identity_id`.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.updateIdentity(
@@ -151,13 +143,13 @@ if (response.status !== 200 || !response.data) {
 | `balanceId` | string | Yes | The balance ID to update. |
 | `data.identity_id` | string | Yes | The identity ID to link. |
 
-See [Update balance identity](/reference/update-balance-identity) for all request fields and the response.
+See [Update balance identity](/reference/update-balance-identity) for request fields, response shape, and validation.
 
 ---
 
-## `createSnapshot`
+## Trigger balance snapshots
 
-Trigger daily balance snapshots in batches. Omit `batch_size` or pass `0` to use the server default (1000).
+`blnk.LedgerBalances.createSnapshot` triggers daily balance snapshots in batches. Omit `batch_size` or pass `0` to use the server default (1000).
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.createSnapshot({ batch_size: 500 });
@@ -175,13 +167,15 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `options.batch_size` | number | No | Balances processed per batch. Positive values are sent as a query param; omit or pass `0` for the server default. |
 
-See [Balance snapshots](/reference/balances-snapshots) for query parameters and the response, and the [Balance snapshots guide](/balances/balance-snapshots) for setup and concepts.
+For setup and concepts, see the [Balance snapshots guide](/balances/balance-snapshots).
+
+See [Balance snapshots](/reference/balances-snapshots) for request fields, response shape, and validation.
 
 ---
 
-## `getAt`
+## Get historical balance
 
-Retrieve a balance at a specific point in time. Pass an ISO 8601 timestamp (RFC3339). Set `from_source: true` to reconstruct from transactions instead of snapshots.
+`blnk.LedgerBalances.getAt` retrieves a balance at a specific point in time. Pass an ISO 8601 timestamp (RFC3339). Set `from_source: true` to reconstruct from transactions instead of snapshots.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.getAt(
@@ -211,13 +205,15 @@ const response = await blnk.LedgerBalances.getAt(
 | `options.timestamp` | string | Yes | ISO 8601 timestamp (for example `2025-02-24T08:55:26Z`). |
 | `options.from_source` | boolean | No | When `true`, reconstruct from transactions instead of snapshots. |
 
-See [Historical balances](/reference/historical-balances) for query parameters and response fields, and the [Historical balances guide](/balances/historical-balances) for concepts.
+For concepts, see the [Historical balances guide](/balances/historical-balances).
+
+See [Historical balances](/reference/historical-balances) for request fields, response shape, and validation.
 
 ---
 
-## `getLineage`
+## Get balance lineage
 
-Inspect provider-level fund breakdown for a balance with [fund lineage](/transactions/lineage) enabled. Returns received, spent, and available amounts per provider in minor units.
+`blnk.LedgerBalances.getLineage` inspects provider-level fund breakdown for a balance with [fund lineage](/transactions/lineage) enabled. Returns received, spent, and available amounts per provider in minor units.
 
 ```typescript wrap
 const response = await blnk.LedgerBalances.getLineage(
@@ -237,4 +233,28 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `balanceId` | string | Yes | The balance ID with fund lineage enabled. |
 
-See [View balance lineage](/reference/get-balance-lineage) for all response fields, and the [Fund lineage guide](/transactions/lineage) for setup and concepts.
+For setup and concepts, see the [Fund lineage guide](/transactions/lineage).
+
+See [View balance lineage](/reference/get-balance-lineage) for request fields, response shape, and validation.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Transactions" icon="arrow-left-right" href="/sdks/typescript/transactions">
+Move funds between balances with `blnk.Transactions`.
+</Card>
+
+<Card title="Identities" icon="user" href="/sdks/typescript/identities">
+Register customers and link them to balances.
+</Card>
+
+<Card title="Balance monitoring" icon="bell" href="/sdks/typescript/balance-monitors">
+Attach webhook conditions to balances.
+</Card>
+
+<Card title="CLI balances" icon="terminal" href="/cli/balances">
+Create and list balances from the terminal.
+</Card>
+</CardGroup>

--- a/sdks/typescript/identities.mdx
+++ b/sdks/typescript/identities.mdx
@@ -2,19 +2,20 @@
 title: "Identities"
 sidebarTitle: "Identities"
 icon: "user"
-description: "Use the Blnk TypeScript SDK to create, retrieve, list, and update identities on your Core instance."
+description: "Use the Blnk TypeScript SDK to create, retrieve, list, update, and search identities on your Core instance."
 "og:title": "Identities • Blnk TypeScript SDK"
-"og:description": "Use the Blnk TypeScript SDK to create, retrieve, list, and update identities on your Core instance."
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, list, update, and search identities on your Core instance."
 ---
+
+## Overview
 
 Use `blnk.Identity` to register customers or organizations, link them to balances, and maintain profile data on your ledger.
 
-| Method | API Reference | Description |
-| :--- | :--- | :--- |
-| `create` | [Create identity](/reference/create-identity) | Register a new identity |
-| `get` | [Get identity](/reference/get-identity) | Fetch one identity by `identity_id` |
-| `list` | [Get identity](/reference/get-identity) | List all identities |
-| `update` | [Edit identity](/reference/edit-identity) | Update identity fields |
+For concepts and PII handling, see the [Identities guide](/identities/introduction).
+
+## Key concepts
+
+For large datasets, prefer `blnk.Search` over `list` — see [Search identities](#search-identities) and the [Search SDK page](/sdks/typescript/search).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -22,22 +23,37 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `create`
+## Create an identity
 
-Register an individual or organization identity. Use the returned `identity_id` when linking balances.
+`blnk.Identity.create` registers an individual or organization identity. Use the returned `identity_id` when linking balances.
 
-See [Create identity](/reference/create-identity) for all request fields and the response. Required fields vary by `identity_type`.
+Only `identity_type` is required. All other fields are optional and validated by the SDK when provided (for example `identity_id`, `dob`, `gender`).
+
+**Minimal create** — only `identity_type`:
+
+```typescript wrap
+const response = await blnk.Identity.create({
+  identity_type: 'individual',
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+**Full create** with optional caller-supplied `identity_id` (`idt_` + UUID) and ISO 8601 `dob`:
 
 ```typescript wrap expandable
 const response = await blnk.Identity.create({
+  identity_id: 'idt_11111111-1111-4111-8111-111111111111',
   identity_type: 'individual',
   first_name: 'Jane',
   last_name: 'Doe',
   gender: 'female',
-  nationality: 'US',
-  dob: new Date('1990-01-15'),
+  dob: '1990-01-15T00:00:00Z',
   email_address: 'jane@example.com',
   phone_number: '+1234567890',
+  nationality: 'US',
   category: 'customer',
   street: '123 Main St',
   city: 'New York',
@@ -55,11 +71,13 @@ if (response.status !== 201 || !response.data) {
 CLI equivalent: `blnk identities create`. See [CLI identities](/cli/identities).
 </Tip>
 
+See [Create identity](/reference/create-identity) for request fields, response shape, and validation.
+
 ---
 
-## `get`
+## Get an identity
 
-Fetch one identity by ID.
+`blnk.Identity.get` fetches one identity by ID.
 
 ```typescript wrap
 const response = await blnk.Identity.get(
@@ -71,13 +89,13 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Get identity](/reference/get-identity) for all response fields.
+See [Get identity](/reference/get-identity) for request fields, response shape, and validation.
 
 ---
 
-## `list`
+## List identities
 
-Return all identities on your Core instance.
+`blnk.Identity.list` returns all identities on your Core instance. For large datasets, prefer `Search.search` or `Search.filter` — see [Search identities](#search-identities).
 
 ```typescript wrap
 const response = await blnk.Identity.list();
@@ -87,13 +105,13 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Get identity](/reference/get-identity) for all response fields.
+See [Get identity](/reference/get-identity) for request fields, response shape, and validation.
 
 ---
 
-## `update`
+## Update an identity
 
-Update fields on an existing identity.
+`blnk.Identity.update` changes fields on an existing identity.
 
 ```typescript wrap
 const response = await blnk.Identity.update(
@@ -106,4 +124,63 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Edit identity](/reference/edit-identity) for all request fields and the response. See the [Identities guide](/identities/introduction) for linking balances and PII tokenization.
+For linking balances and PII tokenization, see the [Identities guide](/identities/introduction).
+
+See [Edit identity](/reference/edit-identity) for request fields, response shape, and validation.
+
+---
+
+## Search identities
+
+Use `blnk.Search` when you need to query identities without loading the full list.
+
+**Typesense** — full-text search on indexed fields:
+
+```typescript wrap
+const response = await blnk.Search.search(
+  {
+    q: 'jane',
+    query_by: 'first_name,last_name,email_address',
+    per_page: 10,
+  },
+  'identities',
+);
+```
+
+**Database filter** — structured filters on identity fields:
+
+```typescript wrap
+const response = await blnk.Search.filter(
+  {
+    filters: [{ field: 'identity_type', operator: 'eq', value: 'individual' }],
+    limit: 20,
+  },
+  'identities',
+);
+```
+
+For when to use Typesense vs DB filters, reindex helpers, and response typing, see [Search](/sdks/typescript/search).
+
+See [Search via Typesense](/reference/search-typesense) for Typesense query fields and [Search via DB](/reference/search-db) for filter fields.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Balances" icon="wallet" href="/sdks/typescript/balances">
+Link identities to balances with `updateIdentity`.
+</Card>
+
+<Card title="Search" icon="search" href="/sdks/typescript/search">
+Full search and filter reference for all collections.
+</Card>
+
+<Card title="Identities guide" icon="book-open" href="/identities/introduction">
+Linking, tokenization, and use cases.
+</Card>
+
+<Card title="CLI identities" icon="terminal" href="/cli/identities">
+Create and manage identities from the terminal.
+</Card>
+</CardGroup>

--- a/sdks/typescript/identities.mdx
+++ b/sdks/typescript/identities.mdx
@@ -1,0 +1,105 @@
+---
+title: "Identities"
+sidebarTitle: "Identities"
+icon: "user"
+description: "Use the Blnk TypeScript SDK to create, retrieve, list, and update identities on your Core instance."
+"og:title": "Identities • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, list, and update identities on your Core instance."
+---
+
+Use `blnk.Identity` to register customers or organizations, link them to balances, and maintain profile data on your ledger.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create identity](/reference/create-identity) | Register a new identity |
+| `get` | [Get identity](/reference/get-identity) | Fetch one identity by `identity_id` |
+| `list` | [Get identity](/reference/get-identity) | List all identities |
+| `update` | [Edit identity](/reference/edit-identity) | Update identity fields |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Register an individual or organization identity. Use the returned `identity_id` when linking balances.
+
+See [Create identity](/reference/create-identity) for required fields by `identity_type`.
+
+```typescript wrap expandable
+const response = await blnk.Identity.create({
+  identity_type: 'individual',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  gender: 'female',
+  nationality: 'US',
+  dob: new Date('1990-01-15'),
+  email_address: 'jane@example.com',
+  phone_number: '+1234567890',
+  category: 'customer',
+  street: '123 Main St',
+  city: 'New York',
+  state: 'NY',
+  country: 'USA',
+  post_code: '10001',
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk identities create`. See [CLI identities](/cli/identities).
+</Tip>
+
+---
+
+## `get`
+
+Fetch one identity by ID.
+
+```typescript wrap
+const response = await blnk.Identity.get(
+  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `list`
+
+Return all identities on your Core instance.
+
+```typescript wrap
+const response = await blnk.Identity.list();
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+---
+
+## `update`
+
+Update fields on an existing identity.
+
+```typescript wrap
+const response = await blnk.Identity.update(
+  'idt_8cc22560-5ace-4989-8953-fcbad7947d48',
+  { first_name: 'Jane', last_name: 'Smith' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Identities guide](/identities/introduction) for linking balances and PII tokenization.

--- a/sdks/typescript/identities.mdx
+++ b/sdks/typescript/identities.mdx
@@ -26,7 +26,7 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 Register an individual or organization identity. Use the returned `identity_id` when linking balances.
 
-See [Create identity](/reference/create-identity) for required fields by `identity_type`.
+See [Create identity](/reference/create-identity) for all request fields and the response. Required fields vary by `identity_type`.
 
 ```typescript wrap expandable
 const response = await blnk.Identity.create({
@@ -71,6 +71,8 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
+See [Get identity](/reference/get-identity) for all response fields.
+
 ---
 
 ## `list`
@@ -84,6 +86,8 @@ if (response.status !== 200 || !response.data) {
   console.error(`Error ${response.status}: ${response.message}`);
 }
 ```
+
+See [Get identity](/reference/get-identity) for all response fields.
 
 ---
 
@@ -102,4 +106,4 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Identities guide](/identities/introduction) for linking balances and PII tokenization.
+See [Edit identity](/reference/edit-identity) for all request fields and the response. See the [Identities guide](/identities/introduction) for linking balances and PII tokenization.

--- a/sdks/typescript/ledgers.mdx
+++ b/sdks/typescript/ledgers.mdx
@@ -7,7 +7,7 @@ description: "Use the Blnk TypeScript SDK to create, retrieve, and update ledger
 "og:description": "Use the Blnk TypeScript SDK to create, retrieve, and update ledgers on your Core instance."
 ---
 
-Use `blnk.Ledgers` to create ledger containers, fetch ledger records, and rename books. Ledgers group balances and transactions. Create one before opening balances on a book.
+Use `blnk.Ledgers` to create ledgers, fetch ledger records, and rename books. Ledgers group balances and transactions. Create one before opening balances on a book.
 
 Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
 
@@ -25,9 +25,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ## `create`
 
-Create a ledger container. You need a `ledger_id` from the response before creating balances.
+Create a ledger. You need a `ledger_id` from the response before creating balances.
 
-See [Create ledger](/reference/create-ledger) for all request fields.
+See [Create ledger](/reference/create-ledger) for all request fields and the response.
 
 ```typescript wrap
 const response = await blnk.Ledgers.create({
@@ -72,7 +72,7 @@ if (response.status !== 200 || !response.data) {
 CLI equivalent: `blnk ledgers list --id <ledger-id>`. See [CLI ledgers](/cli/ledgers).
 </Tip>
 
-See [Get ledger](/reference/get-ledger) for the full response shape.
+See [Get ledger](/reference/get-ledger) for all response fields.
 
 ---
 
@@ -100,4 +100,4 @@ if (response.status !== 200 || !response.data) {
 | `id` | string | Yes | The ledger ID to update. |
 | `data.name` | string | Yes | The new ledger name. |
 
-See [Update ledger name](/reference/update-ledger-name) for the full response shape.
+See [Update ledger name](/reference/update-ledger-name) for all request fields and the response.

--- a/sdks/typescript/ledgers.mdx
+++ b/sdks/typescript/ledgers.mdx
@@ -2,17 +2,20 @@
 title: "Ledgers"
 sidebarTitle: "Ledgers"
 icon: "book-open"
-description: "Use the Blnk TypeScript SDK to create and retrieve ledgers on your Core instance."
+description: "Use the Blnk TypeScript SDK to create, retrieve, and update ledgers on your Core instance."
 "og:title": "Ledgers • Blnk TypeScript SDK"
-"og:description": "Use the Blnk TypeScript SDK to create and retrieve ledgers on your Core instance."
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, and update ledgers on your Core instance."
 ---
 
-Use `blnk.Ledgers` to create ledger containers and fetch ledger records. Ledgers group balances and transactions. Create one before opening balances on a book.
+Use `blnk.Ledgers` to create ledger containers, fetch ledger records, and rename books. Ledgers group balances and transactions. Create one before opening balances on a book.
+
+Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
 
 | Method | API Reference | Description |
 | :--- | :--- | :--- |
 | `create` | [Create ledger](/reference/create-ledger) | Create a new ledger |
 | `get` | [Get ledger](/reference/get-ledger) | Fetch a ledger by `ledger_id` |
+| `update` | [Update ledger name](/reference/update-ledger-name) | Rename an existing ledger |
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -70,3 +73,31 @@ CLI equivalent: `blnk ledgers list --id <ledger-id>`. See [CLI ledgers](/cli/led
 </Tip>
 
 See [Get ledger](/reference/get-ledger) for the full response shape.
+
+---
+
+## `update`
+
+Rename an existing ledger. Only the `name` field is writable on this endpoint.
+
+```typescript wrap
+const response = await blnk.Ledgers.update(
+  'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
+  { name: 'Updated Customer Savings Ledger' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.name);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | string | Yes | The ledger ID to update. |
+| `data.name` | string | Yes | The new ledger name. |
+
+See [Update ledger name](/reference/update-ledger-name) for the full response shape.

--- a/sdks/typescript/ledgers.mdx
+++ b/sdks/typescript/ledgers.mdx
@@ -1,0 +1,72 @@
+---
+title: "Ledgers"
+sidebarTitle: "Ledgers"
+icon: "book-open"
+description: "Use the Blnk TypeScript SDK to create and retrieve ledgers on your Core instance."
+"og:title": "Ledgers • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create and retrieve ledgers on your Core instance."
+---
+
+Use `blnk.Ledgers` to create ledger containers and fetch ledger records. Ledgers group balances and transactions. Create one before opening balances on a book.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create ledger](/reference/create-ledger) | Create a new ledger |
+| `get` | [Get ledger](/reference/get-ledger) | Fetch a ledger by `ledger_id` |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Create a ledger container. You need a `ledger_id` from the response before creating balances.
+
+See [Create ledger](/reference/create-ledger) for all request fields.
+
+```typescript wrap
+const response = await blnk.Ledgers.create({
+  name: 'Customer accounts',
+  meta_data: { project_owner: 'MyApp' },
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.ledger_id);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk ledgers create`. See [CLI ledgers](/cli/ledgers).
+</Tip>
+
+---
+
+## `get`
+
+Fetch one ledger by ID, including its name and metadata.
+
+```typescript wrap
+const response = await blnk.Ledgers.get(
+  'ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | string | Yes | The ledger ID (for example `ldg_049495c6-356e-4ebc-a45e-60d1e1e16afb`). |
+
+<Tip>
+CLI equivalent: `blnk ledgers list --id <ledger-id>`. See [CLI ledgers](/cli/ledgers).
+</Tip>
+
+See [Get ledger](/reference/get-ledger) for the full response shape.

--- a/sdks/typescript/ledgers.mdx
+++ b/sdks/typescript/ledgers.mdx
@@ -7,15 +7,11 @@ description: "Use the Blnk TypeScript SDK to create, retrieve, and update ledger
 "og:description": "Use the Blnk TypeScript SDK to create, retrieve, and update ledgers on your Core instance."
 ---
 
-Use `blnk.Ledgers` to create ledgers, fetch ledger records, and rename books. Ledgers group balances and transactions. Create one before opening balances on a book.
+## Overview
 
-Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
+Use `blnk.Ledgers` to create ledgers, fetch ledger records, and rename books. Ledgers group balances and transactions — create one before creating balances on a book.
 
-| Method | API Reference | Description |
-| :--- | :--- | :--- |
-| `create` | [Create ledger](/reference/create-ledger) | Create a new ledger |
-| `get` | [Get ledger](/reference/get-ledger) | Fetch a ledger by `ledger_id` |
-| `update` | [Update ledger name](/reference/update-ledger-name) | Rename an existing ledger |
+For concepts and setup, see the [Ledgers guide](/ledgers/introduction).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -23,11 +19,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `create`
+## Create a ledger
 
-Create a ledger. You need a `ledger_id` from the response before creating balances.
-
-See [Create ledger](/reference/create-ledger) for all request fields and the response.
+`blnk.Ledgers.create` registers a new book. You need the `ledger_id` from the response before creating balances.
 
 ```typescript wrap
 const response = await blnk.Ledgers.create({
@@ -46,11 +40,13 @@ if (response.status !== 201 || !response.data) {
 CLI equivalent: `blnk ledgers create`. See [CLI ledgers](/cli/ledgers).
 </Tip>
 
+See [Create ledger](/reference/create-ledger) for request fields, response shape, and validation.
+
 ---
 
-## `get`
+## Get a ledger
 
-Fetch one ledger by ID, including its name and metadata.
+`blnk.Ledgers.get` fetches one ledger by ID, including its name and metadata.
 
 ```typescript wrap
 const response = await blnk.Ledgers.get(
@@ -72,13 +68,13 @@ if (response.status !== 200 || !response.data) {
 CLI equivalent: `blnk ledgers list --id <ledger-id>`. See [CLI ledgers](/cli/ledgers).
 </Tip>
 
-See [Get ledger](/reference/get-ledger) for all response fields.
+See [Get ledger](/reference/get-ledger) for request fields, response shape, and validation.
 
 ---
 
-## `update`
+## Update a ledger name
 
-Rename an existing ledger. Only the `name` field is writable on this endpoint.
+`blnk.Ledgers.update` renames an existing ledger. Only the `name` field is writable on this endpoint.
 
 ```typescript wrap
 const response = await blnk.Ledgers.update(
@@ -100,4 +96,26 @@ if (response.status !== 200 || !response.data) {
 | `id` | string | Yes | The ledger ID to update. |
 | `data.name` | string | Yes | The new ledger name. |
 
-See [Update ledger name](/reference/update-ledger-name) for all request fields and the response.
+See [Update ledger name](/reference/update-ledger-name) for request fields, response shape, and validation.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Balances" icon="wallet" href="/sdks/typescript/balances">
+Create balances on a ledger with `blnk.LedgerBalances`.
+</Card>
+
+<Card title="Transactions" icon="arrow-left-right" href="/sdks/typescript/transactions">
+Move funds between balances after you have a book and accounts.
+</Card>
+
+<Card title="Ledgers guide" icon="book-open" href="/ledgers/introduction">
+Concepts, use cases, and Core API background.
+</Card>
+
+<Card title="CLI ledgers" icon="terminal" href="/cli/ledgers">
+Manage ledgers from the terminal.
+</Card>
+</CardGroup>

--- a/sdks/typescript/reconciliation.mdx
+++ b/sdks/typescript/reconciliation.mdx
@@ -36,7 +36,7 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Upload data](/reference/upload-data) and the [Reconciliation overview](/reconciliations/overview).
+See [Upload data](/reference/upload-data) for all request fields and the response, and the [Reconciliation overview](/reconciliations/overview) for workflow and concepts.
 
 ---
 
@@ -56,7 +56,7 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Create matching rule](/reference/create-matching-rule) and [Matching rules](/reconciliations/matching-rules).
+See [Create matching rule](/reference/create-matching-rule) for all request fields and the response, and [Matching rules](/reconciliations/matching-rules) for criteria and examples.
 
 ---
 
@@ -82,4 +82,4 @@ if (response.status !== 200 || !response.data) {
 CLI equivalent: `blnk reconciliations`. See [CLI reconciliations](/cli/reconciliations).
 </Tip>
 
-See [Start reconciliation](/reference/start-reconciliation).
+See [Start reconciliation](/reference/start-reconciliation) for all request fields and the response.

--- a/sdks/typescript/reconciliation.mdx
+++ b/sdks/typescript/reconciliation.mdx
@@ -7,13 +7,11 @@ description: "Use the Blnk TypeScript SDK to upload external data, define matchi
 "og:description": "Use the Blnk TypeScript SDK to upload external data, define matching rules, and run reconciliations."
 ---
 
+## Overview
+
 Use `blnk.Reconciliation` to match external statements against ledger records. Upload a file, define how rows match transactions, then start a reconciliation run.
 
-| Method | API Reference | Description |
-| :--- | :--- | :--- |
-| `upload` | [Upload data](/reference/upload-data) | Upload an external data file |
-| `createMatchingRule` | [Create matching rule](/reference/create-matching-rule) | Define how records match |
-| `run` | [Start reconciliation](/reference/start-reconciliation) | Run reconciliation against an upload |
+For workflow and concepts, see the [Reconciliation overview](/reconciliations/overview).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -21,9 +19,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `upload`
+## Upload reconciliation data
 
-Upload a CSV or other external data file for reconciliation. Pass a local file path and a source label.
+`blnk.Reconciliation.upload` uploads a CSV or other external data file for reconciliation. Pass a local file path and a source label.
 
 ```typescript wrap
 const response = await blnk.Reconciliation.upload(
@@ -36,13 +34,15 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Upload data](/reference/upload-data) for all request fields and the response, and the [Reconciliation overview](/reconciliations/overview) for workflow and concepts.
+For workflow and concepts, see the [Reconciliation overview](/reconciliations/overview).
+
+See [Upload data](/reference/upload-data) for request fields, response shape, and validation.
 
 ---
 
-## `createMatchingRule`
+## Create a matching rule
 
-Define criteria for matching uploaded rows to ledger transactions.
+`blnk.Reconciliation.createMatchingRule` defines criteria for matching uploaded rows to ledger transactions.
 
 ```typescript wrap
 const response = await blnk.Reconciliation.createMatchingRule({
@@ -56,13 +56,15 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Create matching rule](/reference/create-matching-rule) for all request fields and the response, and [Matching rules](/reconciliations/matching-rules) for criteria and examples.
+For criteria and examples, see [Matching rules](/reconciliations/matching-rules).
+
+See [Create matching rule](/reference/create-matching-rule) for request fields, response shape, and validation.
 
 ---
 
-## `run`
+## Run reconciliation
 
-Start a reconciliation run against a previously uploaded file.
+`blnk.Reconciliation.run` starts a reconciliation run against a previously uploaded file.
 
 ```typescript wrap
 const response = await blnk.Reconciliation.run({
@@ -82,4 +84,59 @@ if (response.status !== 200 || !response.data) {
 CLI equivalent: `blnk reconciliations`. See [CLI reconciliations](/cli/reconciliations).
 </Tip>
 
-See [Start reconciliation](/reference/start-reconciliation) for all request fields and the response.
+See [Start reconciliation](/reference/start-reconciliation) for request fields, response shape, and validation.
+
+---
+
+## Run instant reconciliation
+
+`blnk.Reconciliation.runInstant` reconciles inline external transactions without uploading a file first.
+
+```typescript wrap
+const response = await blnk.Reconciliation.runInstant({
+  external_transactions: [
+    {
+      id: 'txn_1',
+      amount: 5.49,
+      reference: 'INV-2023-002',
+      currency: 'GBP',
+      description: 'Card payment',
+      date: '2024-11-15T14:25:30Z',
+      source: 'bank-api',
+    },
+  ],
+  strategy: 'one_to_one',
+  dry_run: true,
+  matching_rule_ids: ['rule_abc123'],
+});
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+For workflow and concepts, see [Instant reconciliation](/reconciliations/overview#option-2-instant-reconciliation).
+
+See [Instant reconciliation](/reference/instant-reconciliation) for request fields, response shape, and validation.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Transactions" icon="arrow-left-right" href="/sdks/typescript/transactions">
+Inspect and match ledger transactions.
+</Card>
+
+<Card title="Matching rules" icon="scale" href="/reconciliations/matching-rules">
+Criteria, operators, and examples.
+</Card>
+
+<Card title="SDK examples" icon="github" href="https://github.com/blnkfinance/blnk-ts/tree/main/examples">
+Reconciliation sample in the TypeScript repo.
+</Card>
+
+<Card title="CLI reconciliations" icon="terminal" href="/cli/reconciliations">
+Run reconciliations from the terminal.
+</Card>
+</CardGroup>

--- a/sdks/typescript/reconciliation.mdx
+++ b/sdks/typescript/reconciliation.mdx
@@ -1,0 +1,85 @@
+---
+title: "Reconciliation"
+sidebarTitle: "Reconciliation"
+icon: "scale"
+description: "Use the Blnk TypeScript SDK to upload external data, define matching rules, and run reconciliations."
+"og:title": "Reconciliation • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to upload external data, define matching rules, and run reconciliations."
+---
+
+Use `blnk.Reconciliation` to match external statements against ledger records. Upload a file, define how rows match transactions, then start a reconciliation run.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `upload` | [Upload data](/reference/upload-data) | Upload an external data file |
+| `createMatchingRule` | [Create matching rule](/reference/create-matching-rule) | Define how records match |
+| `run` | [Start reconciliation](/reference/start-reconciliation) | Run reconciliation against an upload |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `upload`
+
+Upload a CSV or other external data file for reconciliation. Pass a local file path and a source label.
+
+```typescript wrap
+const response = await blnk.Reconciliation.upload(
+  'statement.csv',
+  'stripe',
+);
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Upload data](/reference/upload-data) and the [Reconciliation overview](/reconciliations/overview).
+
+---
+
+## `createMatchingRule`
+
+Define criteria for matching uploaded rows to ledger transactions.
+
+```typescript wrap
+const response = await blnk.Reconciliation.createMatchingRule({
+  name: 'Amount match',
+  description: 'Match by amount',
+  criteria: [{ field: 'amount', operator: 'equals', allowable_drift: 0.01 }],
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+See [Create matching rule](/reference/create-matching-rule) and [Matching rules](/reconciliations/matching-rules).
+
+---
+
+## `run`
+
+Start a reconciliation run against a previously uploaded file.
+
+```typescript wrap
+const response = await blnk.Reconciliation.run({
+  upload_id: 'upl_f3a8b2c1-9d4e-4a7b-8c6e-1f2d3e4a5b6c',
+  strategy: 'one_to_one',
+  dry_run: true,
+  grouping_criteria: 'amount',
+  matching_rule_ids: ['rule_abc123'],
+});
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Tip>
+CLI equivalent: `blnk reconciliations`. See [CLI reconciliations](/cli/reconciliations).
+</Tip>
+
+See [Start reconciliation](/reference/start-reconciliation).

--- a/sdks/typescript/search.mdx
+++ b/sdks/typescript/search.mdx
@@ -2,16 +2,28 @@
 title: "Search"
 sidebarTitle: "Search"
 icon: "search"
-description: "Use the Blnk TypeScript SDK to search ledgers, balances, and transactions via Typesense."
+description: "Use the Blnk TypeScript SDK for Typesense full-text search, database filters, and Typesense reindex operations."
 "og:title": "Search • Blnk TypeScript SDK"
-"og:description": "Use the Blnk TypeScript SDK to search ledgers, balances, and transactions via Typesense."
+"og:description": "Use the Blnk TypeScript SDK for Typesense full-text search, database filters, and Typesense reindex operations."
 ---
 
-Use `blnk.Search` for full-text search powered by Typesense. Pass a query object and a collection name to search across ledgers, balances, or transactions.
+## Overview
 
-| Method | API Reference | Description |
-| :--- | :--- | :--- |
-| `search` | [Search via Typesense](/reference/search-typesense) | Full-text search on a collection |
+Use `blnk.Search` to query ledgers, balances, transactions, and identities. Blnk exposes two complementary query modes — pick the one that fits your use case.
+
+Collections for both modes: `'ledgers'`, `'balances'`, `'transactions'`, `'identities'`.
+
+## Key concepts
+
+<Info>
+**Typesense vs database filter**
+
+- Use **`search`** when you need full-text matching (`q`, `query_by`, `filter_by`), relevance ranking, or Typesense-specific features. See [Search a collection](#search-a-collection) and the [Typesense guide](/search/typesense/introduction).
+- Use **`filter`** when you need exact field filters (`eq`, `in`, `gte`, etc.) against Postgres with a JSON filter body. See [Filter a collection](#filter-a-collection) and [DB filtering](/search/db/filtering).
+- Both modes return collection-specific record shapes. `search` returns Typesense-indexed documents; `filter` returns full Core API records.
+</Info>
+
+Reindex helpers rebuild the Typesense index from your database when Typesense is empty or out of sync. See [Start a reindex](#start-a-reindex) and [Get reindex status](#get-reindex-status).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -19,9 +31,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `search`
+## Search a collection
 
-Run a Typesense query against a collection. Pass `'ledgers'`, `'transactions'`, or `'balances'` as the second argument.
+`blnk.Search.search` runs a Typesense query against a collection. The second argument narrows the response type to that collection's indexed document shape.
 
 ```typescript wrap
 const response = await blnk.Search.search(
@@ -29,8 +41,10 @@ const response = await blnk.Search.search(
   'transactions',
 );
 
-if (response.status !== 200 || !response.data) {
+if (response.status !== 201 || !response.data) {
   console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.found, response.data.hits[0]?.document.transaction_id);
 }
 ```
 
@@ -39,7 +53,7 @@ if (response.status !== 200 || !response.data) {
 | Parameter | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `params` | object | Yes | Search query (for example `{ q: 'payment', per_page: 20 }`). |
-| `collection` | string | Yes | Collection name: `'ledgers'`, `'transactions'`, or `'balances'`. |
+| `collection` | string | Yes | `'ledgers'`, `'transactions'`, `'balances'`, or `'identities'`. |
 
 <CodeGroup>
 ```typescript Transactions wrap
@@ -62,10 +76,144 @@ const response = await blnk.Search.search(
   'ledgers',
 );
 ```
+
+```typescript Identities wrap
+const response = await blnk.Search.search(
+  {
+    q: 'jane',
+    query_by: 'first_name,last_name,email_address',
+    per_page: 10,
+  },
+  'identities',
+);
+```
 </CodeGroup>
 
-See [Search via Typesense](/reference/search-typesense) for all request fields and response fields, and the [Typesense introduction](/search/typesense/introduction) for setup and concepts.
+See [Search via Typesense](/reference/search-typesense) for request fields, response shape, and validation.
 
-<Note>
-For structured DB queries without Typesense, use the [Search via DB](/reference/search-db) HTTP API directly. SDK support for DB filter and reindex is coming soon.
-</Note>
+---
+
+## Filter a collection
+
+`blnk.Search.filter` queries records with structured JSON filters against the database. Use this when Typesense full-text search is not required.
+
+```typescript wrap
+const response = await blnk.Search.filter(
+  {
+    filters: [{ field: 'status', operator: 'eq', value: 'APPLIED' }],
+    logical_operator: 'and',
+    sort_by: 'created_at',
+    sort_order: 'desc',
+    include_count: true,
+    limit: 20,
+    offset: 0,
+  },
+  'transactions',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.total_count, response.data.data[0]?.transaction_id);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `params` | object | Yes | Filter body with a `filters` array and optional sort/pagination fields. |
+| `collection` | string | Yes | `'ledgers'`, `'transactions'`, `'balances'`, or `'identities'`. |
+
+<CodeGroup>
+```typescript Transactions wrap
+const response = await blnk.Search.filter(
+  {
+    filters: [{ field: 'status', operator: 'eq', value: 'APPLIED' }],
+    include_count: true,
+    limit: 20,
+  },
+  'transactions',
+);
+```
+
+```typescript Identities wrap
+const response = await blnk.Search.filter(
+  {
+    filters: [{ field: 'identity_type', operator: 'eq', value: 'individual' }],
+    limit: 10,
+  },
+  'identities',
+);
+```
+</CodeGroup>
+
+For supported operators and fields, see [DB filtering](/search/db/filtering).
+
+See [Search via DB](/reference/search-db) for request fields, response shape, and validation.
+
+---
+
+## Start a reindex
+
+`blnk.Search.startReindex` populates or rebuilds Typesense from your existing database — for example after spinning up a new Typesense instance. The job runs asynchronously on Core.
+
+```typescript wrap
+const response = await blnk.Search.startReindex({ batch_size: 1000 });
+
+if (response.status !== 202 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.message, response.data.progress.status);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `options` | object | No | Optional `{ batch_size: number }`. Omit to send `{}` and use the Core default. |
+
+See [Start reindex](/reference/start-reindex) for request fields, response shape, and validation.
+
+---
+
+## Get reindex status
+
+`blnk.Search.getReindexStatus` polls reindex progress after calling `startReindex`.
+
+```typescript wrap
+const response = await blnk.Search.getReindexStatus();
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.status, response.data.phase);
+}
+```
+
+Returns `404` when no reindex has been started on the instance.
+
+See [Get reindex status](/reference/get-reindex) for request fields, response shape, and validation.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Identities" icon="user" href="/sdks/typescript/identities">
+CRUD plus identity search examples.
+</Card>
+
+<Card title="Typesense guide" icon="search" href="/search/typesense/introduction">
+Indexing, query syntax, and setup.
+</Card>
+
+<Card title="DB filtering" icon="database" href="/search/db/filtering">
+Operators and fields for `filter`.
+</Card>
+
+<Card title="Transactions" icon="arrow-left-right" href="/sdks/typescript/transactions">
+Post and query ledger movements.
+</Card>
+</CardGroup>

--- a/sdks/typescript/search.mdx
+++ b/sdks/typescript/search.mdx
@@ -64,7 +64,7 @@ const response = await blnk.Search.search(
 ```
 </CodeGroup>
 
-See [Search via Typesense](/reference/search-typesense) and the [Typesense introduction](/search/typesense/introduction).
+See [Search via Typesense](/reference/search-typesense) for all request fields and response fields, and the [Typesense introduction](/search/typesense/introduction) for setup and concepts.
 
 <Note>
 For structured DB queries without Typesense, use the [Search via DB](/reference/search-db) HTTP API directly. SDK support for DB filter and reindex is coming soon.

--- a/sdks/typescript/search.mdx
+++ b/sdks/typescript/search.mdx
@@ -1,0 +1,71 @@
+---
+title: "Search"
+sidebarTitle: "Search"
+icon: "search"
+description: "Use the Blnk TypeScript SDK to search ledgers, balances, and transactions via Typesense."
+"og:title": "Search • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to search ledgers, balances, and transactions via Typesense."
+---
+
+Use `blnk.Search` for full-text search powered by Typesense. Pass a query object and a collection name to search across ledgers, balances, or transactions.
+
+| Method | API Reference | Description |
+| :--- | :--- | :--- |
+| `search` | [Search via Typesense](/reference/search-typesense) | Full-text search on a collection |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `search`
+
+Run a Typesense query against a collection. Pass `'ledgers'`, `'transactions'`, or `'balances'` as the second argument.
+
+```typescript wrap
+const response = await blnk.Search.search(
+  { q: 'payment', per_page: 20 },
+  'transactions',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `params` | object | Yes | Search query (for example `{ q: 'payment', per_page: 20 }`). |
+| `collection` | string | Yes | Collection name: `'ledgers'`, `'transactions'`, or `'balances'`. |
+
+<CodeGroup>
+```typescript Transactions wrap
+const response = await blnk.Search.search(
+  { q: 'payment', per_page: 20 },
+  'transactions',
+);
+```
+
+```typescript Balances wrap
+const response = await blnk.Search.search(
+  { q: 'USD', per_page: 20 },
+  'balances',
+);
+```
+
+```typescript Ledgers wrap
+const response = await blnk.Search.search(
+  { q: 'customer', per_page: 20 },
+  'ledgers',
+);
+```
+</CodeGroup>
+
+See [Search via Typesense](/reference/search-typesense) and the [Typesense introduction](/search/typesense/introduction).
+
+<Note>
+For structured DB queries without Typesense, use the [Search via DB](/reference/search-db) HTTP API directly. SDK support for DB filter and reindex is coming soon.
+</Note>

--- a/sdks/typescript/transactions.mdx
+++ b/sdks/typescript/transactions.mdx
@@ -1,0 +1,198 @@
+---
+title: "Transactions"
+sidebarTitle: "Transactions"
+icon: "arrow-left-right"
+description: "Use the Blnk TypeScript SDK to create, retrieve, update, and refund transactions on your Core instance."
+"og:title": "Transactions • Blnk TypeScript SDK"
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, update, and refund transactions on your Core instance."
+---
+
+Use `blnk.Transactions` to record transfers, submit bulk batches, manage inflight commits and voids, and refund applied posts. Reach for these methods when you are building payment flows, payroll, or any money movement in your application.
+
+Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
+
+| SDK method | API Reference | Description |
+| :--- | :--- | :--- |
+| `create` | [Create transaction](/reference/create-transaction) | Post a single transfer between balances |
+| `get` | [View transaction details](/reference/get-transaction) | Fetch one transaction by `transaction_id` |
+| `getByReference` | [Get transaction by reference](/reference/get-transaction-by-reference) | Fetch one transaction by your unique `reference` |
+| `createBulk` | [Bulk transactions](/reference/bulk-transactions) | Submit multiple transactions in one request |
+| `updateStatus` | [Update inflight](/reference/update-inflight) | Commit or void an inflight transaction |
+| `refund` | [Refund transaction](/reference/refund-transaction) | Reverse an applied transaction |
+
+<Tip>
+Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
+</Tip>
+
+---
+
+## `create`
+
+Post a transfer between a source and destination balance. Supports inflight, scheduling, split legs, and metadata.
+
+See [Create transaction](/reference/create-transaction) for all request fields, validation rules, and status behavior.
+
+```typescript wrap
+const response = await blnk.Transactions.create({
+  amount: 1000,
+  precision: 100,
+  currency: 'USD',
+  source: '@FundingPool',
+  destination: '@MyBalance',
+  reference: 'payment_001',
+  description: 'Customer payment',
+  allow_overdraft: true,
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id, response.data.status);
+}
+```
+
+---
+
+## `get`
+
+Inspect one transaction when you have its `transaction_id`, for example from a `create` response, refund output, or application logs.
+
+```typescript wrap
+const response = await blnk.Transactions.get(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id, response.data.status);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `transactionId` | string | Yes | The transaction ID (for example `txn_14706192-e53d-43cc-86a1-b8807a09b351`). |
+
+<Tip>
+CLI equivalent: `blnk transactions list --id <transaction-id>`. See [CLI transactions](/cli/transactions).
+</Tip>
+
+See [View transaction details](/reference/get-transaction) for the full response shape.
+
+---
+
+## `getByReference`
+
+Look up a transaction using the unique `reference` your application supplied at create time. Use this for idempotency checks, support tooling, or reconciliation when you store references but not Blnk IDs.
+
+The SDK URL-encodes the reference in the request path.
+
+```typescript wrap
+const response = await blnk.Transactions.getByReference('payment_001');
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id, response.data.reference);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `reference` | string | Yes | The unique reference passed when the transaction was created. |
+
+See [Get transaction by reference](/reference/get-transaction-by-reference) for the full response shape.
+
+---
+
+## `createBulk`
+
+Submit multiple transaction records in one request. Use `atomic: true` when every leg must succeed or fail together.
+
+Do not set `status` on bulk create requests. Core manages status during processing.
+
+For concepts and options (`inflight`, `run_async`, `skip_queue`), see the [Bulk transactions guide](/transactions/bulk-transactions).
+
+```typescript wrap expandable
+const response = await blnk.Transactions.createBulk({
+  atomic: true,
+  transactions: [
+    {
+      amount: 1000,
+      precision: 100,
+      currency: 'USD',
+      source: '@source_1',
+      destination: '@dest_1',
+      reference: 'bulk_001',
+      description: 'Payment 1',
+    },
+    {
+      amount: 2000,
+      precision: 100,
+      currency: 'USD',
+      source: '@source_2',
+      destination: '@dest_2',
+      reference: 'bulk_002',
+      description: 'Payment 2',
+    },
+  ],
+});
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.batch_id, response.data.status);
+}
+```
+
+See [Bulk transactions](/reference/bulk-transactions) for request and response fields.
+
+---
+
+## `updateStatus`
+
+Commit or void an inflight transaction. Pass `status: 'commit'` to apply funds, or `status: 'void'` to cancel.
+
+```typescript wrap
+const response = await blnk.Transactions.updateStatus(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+  { status: 'commit' },
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+For partial commits, include `amount` or `precise_amount`. See [Update inflight](/reference/update-inflight) and the [Inflight guide](/transactions/inflight).
+
+---
+
+## `refund`
+
+Reverse an applied transaction. Blnk creates a new transaction that swaps source and destination.
+
+```typescript wrap
+const response = await blnk.Transactions.refund(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+);
+
+if (response.status !== 201 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+}
+```
+
+Pass an optional body to process synchronously:
+
+```typescript wrap
+const response = await blnk.Transactions.refund(
+  'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+  { skip_queue: true },
+);
+```
+
+See [Refund transaction](/reference/refund-transaction) and the [Refunds guide](/transactions/refunds).

--- a/sdks/typescript/transactions.mdx
+++ b/sdks/typescript/transactions.mdx
@@ -7,21 +7,11 @@ description: "Use the Blnk TypeScript SDK to create, retrieve, update, refund, a
 "og:description": "Use the Blnk TypeScript SDK to create, retrieve, update, refund, and bulk-process transactions on your Core instance."
 ---
 
+## Overview
+
 Use `blnk.Transactions` to record transfers, submit bulk batches, manage inflight commits and voids, and refund applied posts. Reach for these methods when you are building payment flows, payroll, or any money movement in your application.
 
-Browse methods in the sidebar or use the summary table below. For field definitions and business rules, open the linked Core API reference for each method.
-
-| SDK method | API Reference | Description |
-| :--- | :--- | :--- |
-| `create` | [Create transaction](/reference/create-transaction) | Post a single transfer between balances |
-| `get` | [View transaction details](/reference/get-transaction) | Fetch one transaction by `transaction_id` |
-| `getByReference` | [Get transaction by reference](/reference/get-transaction-by-reference) | Fetch one transaction by your unique `reference` |
-| `getLineage` | [View transaction lineage](/reference/get-transaction-lineage) | Fetch fund allocation and shadow transactions for a transaction |
-| `createBulk` | [Bulk transactions](/reference/bulk-transactions) | Submit multiple transactions in one request |
-| `updateStatus` | [Update inflight](/reference/update-inflight) | Commit or void one inflight transaction, or an entire inflight batch |
-| `bulkCommitInflight` | [Bulk commit inflight](/reference/bulk-commit-inflight) | Commit up to 100 independently-created inflight transactions |
-| `bulkVoidInflight` | [Bulk void inflight](/reference/bulk-void-inflight) | Void up to 100 independently-created inflight transactions |
-| `refund` | [Refund transaction](/reference/refund-transaction) | Reverse an applied transaction |
+For concepts and flows, see the [Transactions guide](/transactions/introduction).
 
 <Tip>
 Every method returns an `ApiResponse<T>`. Check `response.status` and `response.data` after each call. See [Error handling](/sdks/typescript#error-handling) on the install page.
@@ -29,11 +19,9 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 ---
 
-## `create`
+## Create a transaction
 
-Post a transfer between a source and destination balance. Supports inflight, scheduling, split legs, and metadata.
-
-See [Create transaction](/reference/create-transaction) for all request fields, validation rules, and response fields.
+`blnk.Transactions.create` posts a transfer between a source and destination balance. Supports inflight, scheduling, split legs, and metadata.
 
 ```typescript wrap
 const response = await blnk.Transactions.create({
@@ -54,11 +42,13 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
+See [Create transaction](/reference/create-transaction) for request fields, response shape, and validation.
+
 ---
 
-## `get`
+## Get a transaction
 
-Inspect one transaction when you have its `transaction_id`, for example from a `create` response, refund output, or application logs.
+`blnk.Transactions.get` inspects one transaction when you have its `transaction_id`, for example from a `create` response, refund output, or application logs.
 
 ```typescript wrap
 const response = await blnk.Transactions.get(
@@ -82,13 +72,13 @@ if (response.status !== 200 || !response.data) {
 CLI equivalent: `blnk transactions list --id <transaction-id>`. See [CLI transactions](/cli/transactions).
 </Tip>
 
-See [View transaction details](/reference/get-transaction) for all response fields.
+See [View transaction details](/reference/get-transaction) for request fields, response shape, and validation.
 
 ---
 
-## `getByReference`
+## Get a transaction by reference
 
-Look up a transaction using the unique `reference` your application supplied at create time. Use this for idempotency checks, support tooling, or reconciliation when you store references but not Blnk IDs.
+`blnk.Transactions.getByReference` looks up a transaction using the unique `reference` your application supplied at create time. Use this for idempotency checks, support tooling, or reconciliation when you store references but not Blnk IDs.
 
 The SDK URL-encodes the reference in the request path.
 
@@ -108,13 +98,13 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `reference` | string | Yes | The unique reference passed when the transaction was created. |
 
-See [Get transaction by reference](/reference/get-transaction-by-reference) for all response fields.
+See [Get transaction by reference](/reference/get-transaction-by-reference) for request fields, response shape, and validation.
 
 ---
 
-## `getLineage`
+## Get transaction lineage
 
-Inspect how a transaction's spend was allocated across fund providers and which internal shadow transactions Core created for lineage tracking.
+`blnk.Transactions.getLineage` inspects how a transaction's spend was allocated across fund providers and which internal shadow transactions Core created for lineage tracking.
 
 Most useful for debits from [lineage-enabled balances](/transactions/lineage). Returns how spend was split across providers (`fund_allocation`) and any internal shadow transactions. `fund_allocation` appears on debits from balances with `track_fund_lineage: true` when Core allocated tagged funds; it may be omitted otherwise. `shadow_transactions` may be `null` or an empty array.
 
@@ -138,13 +128,15 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `transactionId` | string | Yes | The transaction ID (for example `txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad`). |
 
-See [View transaction lineage](/reference/get-transaction-lineage) for all response fields, and the [Fund lineage guide](/transactions/lineage) for setup and concepts.
+For setup and concepts, see the [Fund lineage guide](/transactions/lineage).
+
+See [View transaction lineage](/reference/get-transaction-lineage) for request fields, response shape, and validation.
 
 ---
 
-## `createBulk`
+## Submit bulk transactions
 
-Submit multiple transaction records in one request. Each item in `transactions` uses the same fields as [`create`](#create).
+`blnk.Transactions.createBulk` submits multiple transaction records in one request. Each item in `transactions` uses the same fields as [`create`](#create-a-transaction).
 
 For concepts, webhooks, and batch retrieval, see the [Bulk transactions guide](/transactions/bulk-transactions).
 
@@ -238,7 +230,7 @@ if (response.status === 201 && response.data) {
 }
 ```
 
-To commit or void the batch later, call [`updateStatus`](#updatestatus) with the `batch_id`. See [Commit or void bulk inflight](/transactions/bulk-transactions#commit-or-void-bulk-inflight).
+To commit or void the batch later, call [`updateStatus`](#update-inflight-status) with the `batch_id`. See [Commit or void bulk inflight](/transactions/bulk-transactions#commit-or-void-bulk-inflight).
 
 </Tab>
 <Tab title="skip_queue">
@@ -266,13 +258,13 @@ const response = await blnk.Transactions.createBulk({
 </Tab>
 </Tabs>
 
-See [Bulk transactions](/reference/bulk-transactions) for all request fields and response fields.
+See [Bulk transactions](/reference/bulk-transactions) for request fields, response shape, and validation.
 
 ---
 
-## `updateStatus`
+## Update inflight status
 
-Commit or void a single inflight transaction, or an entire inflight **batch** created with [`createBulk`](#createbulk). Pass `status: 'commit'` to apply funds, or `status: 'void'` to cancel.
+`blnk.Transactions.updateStatus` commits or voids a single inflight transaction, or an entire inflight **batch** created with [`createBulk`](#submit-bulk-transactions). Pass `status: 'commit'` to apply funds, or `status: 'void'` to cancel.
 
 ```typescript wrap
 // Single inflight transaction
@@ -292,17 +284,19 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-For partial commits, include `amount` or `precise_amount`. See [Update inflight](/reference/update-inflight) for all request fields and response fields, and the [Inflight guide](/transactions/inflight) for commit and void behavior.
+For partial commits, include `amount` or `precise_amount`. For commit and void behavior, see the [Inflight guide](/transactions/inflight).
 
 <Note>
-For independently-created inflight transactions (not from a bulk batch), use [`bulkCommitInflight`](#bulkcommitinflight) or [`bulkVoidInflight`](#bulkvoidinflight) to commit or void up to 100 at once.
+For independently-created inflight transactions (not from a bulk batch), use [`bulkCommitInflight`](#bulk-commit-inflight-transactions) or [`bulkVoidInflight`](#bulk-void-inflight-transactions) to commit or void up to 100 at once.
 </Note>
+
+See [Update inflight](/reference/update-inflight) for request fields, response shape, and validation.
 
 ---
 
-## `bulkCommitInflight`
+## Bulk commit inflight transactions
 
-Commit multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/commit`). Each request accepts up to 100 items.
+`blnk.Transactions.bulkCommitInflight` commits multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/commit`). Each request accepts up to 100 items.
 
 Omit `amount` and `precise_amount` on an item to commit the full remaining inflight amount. When both are set, `precise_amount` takes precedence.
 
@@ -333,13 +327,15 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Bulk commit inflight](/reference/bulk-commit-inflight) for all request fields and response fields, and [Bulk inflight updates](/transactions/inflight#bulk-inflight-updates) for per-item failure codes and when to use batch `updateStatus` instead.
+See [Bulk inflight updates](/transactions/inflight#bulk-inflight-updates) for per-item failure codes and when to use batch `updateStatus` instead.
+
+See [Bulk commit inflight](/reference/bulk-commit-inflight) for request fields, response shape, and validation.
 
 ---
 
-## `bulkVoidInflight`
+## Bulk void inflight transactions
 
-Void multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/void`). Each request accepts up to 100 transaction IDs.
+`blnk.Transactions.bulkVoidInflight` voids multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/void`). Each request accepts up to 100 transaction IDs.
 
 <Info>Available in Core 0.14.2 and later.</Info>
 
@@ -358,13 +354,15 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-See [Bulk void inflight](/reference/bulk-void-inflight) for all request fields and response fields, and [Bulk inflight updates](/transactions/inflight#bulk-inflight-updates) for per-item failure codes.
+See [Bulk inflight updates](/transactions/inflight#bulk-inflight-updates) for per-item failure codes.
+
+See [Bulk void inflight](/reference/bulk-void-inflight) for request fields, response shape, and validation.
 
 ---
 
-## `refund`
+## Refund a transaction
 
-Reverse an applied transaction. Blnk creates a new transaction that swaps source and destination.
+`blnk.Transactions.refund` reverses an applied transaction. Blnk creates a new transaction that swaps source and destination.
 
 ```typescript wrap
 const response = await blnk.Transactions.refund(
@@ -385,4 +383,28 @@ const response = await blnk.Transactions.refund(
 );
 ```
 
-See [Refund transaction](/reference/refund-transaction) for all request fields and the response, and the [Refunds guide](/transactions/refunds) for reversal behavior.
+For reversal behavior, see the [Refunds guide](/transactions/refunds).
+
+See [Refund transaction](/reference/refund-transaction) for request fields, response shape, and validation.
+
+---
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="Balances" icon="wallet" href="/sdks/typescript/balances">
+Open and manage the accounts you use as `source` and `destination`.
+</Card>
+
+<Card title="Inflight guide" icon="clock" href="/transactions/inflight">
+Commit, void, and bulk inflight workflows.
+</Card>
+
+<Card title="Bulk transactions" icon="layers" href="/transactions/bulk-transactions">
+Batch options, webhooks, and retrieval.
+</Card>
+
+<Card title="CLI transactions" icon="terminal" href="/cli/transactions">
+List and inspect transactions from the terminal.
+</Card>
+</CardGroup>

--- a/sdks/typescript/transactions.mdx
+++ b/sdks/typescript/transactions.mdx
@@ -2,9 +2,9 @@
 title: "Transactions"
 sidebarTitle: "Transactions"
 icon: "arrow-left-right"
-description: "Use the Blnk TypeScript SDK to create, retrieve, update, and refund transactions on your Core instance."
+description: "Use the Blnk TypeScript SDK to create, retrieve, update, refund, and bulk-process transactions on your Core instance."
 "og:title": "Transactions • Blnk TypeScript SDK"
-"og:description": "Use the Blnk TypeScript SDK to create, retrieve, update, and refund transactions on your Core instance."
+"og:description": "Use the Blnk TypeScript SDK to create, retrieve, update, refund, and bulk-process transactions on your Core instance."
 ---
 
 Use `blnk.Transactions` to record transfers, submit bulk batches, manage inflight commits and voids, and refund applied posts. Reach for these methods when you are building payment flows, payroll, or any money movement in your application.
@@ -16,8 +16,11 @@ Browse methods in the sidebar or use the summary table below. For field definiti
 | `create` | [Create transaction](/reference/create-transaction) | Post a single transfer between balances |
 | `get` | [View transaction details](/reference/get-transaction) | Fetch one transaction by `transaction_id` |
 | `getByReference` | [Get transaction by reference](/reference/get-transaction-by-reference) | Fetch one transaction by your unique `reference` |
+| `getLineage` | [View transaction lineage](/reference/get-transaction-lineage) | Fetch fund allocation and shadow transactions for a transaction |
 | `createBulk` | [Bulk transactions](/reference/bulk-transactions) | Submit multiple transactions in one request |
-| `updateStatus` | [Update inflight](/reference/update-inflight) | Commit or void an inflight transaction |
+| `updateStatus` | [Update inflight](/reference/update-inflight) | Commit or void one inflight transaction, or an entire inflight batch |
+| `bulkCommitInflight` | [Bulk commit inflight](/reference/bulk-commit-inflight) | Commit up to 100 independently-created inflight transactions |
+| `bulkVoidInflight` | [Bulk void inflight](/reference/bulk-void-inflight) | Void up to 100 independently-created inflight transactions |
 | `refund` | [Refund transaction](/reference/refund-transaction) | Reverse an applied transaction |
 
 <Tip>
@@ -30,7 +33,7 @@ Every method returns an `ApiResponse<T>`. Check `response.status` and `response.
 
 Post a transfer between a source and destination balance. Supports inflight, scheduling, split legs, and metadata.
 
-See [Create transaction](/reference/create-transaction) for all request fields, validation rules, and status behavior.
+See [Create transaction](/reference/create-transaction) for all request fields, validation rules, and response fields.
 
 ```typescript wrap
 const response = await blnk.Transactions.create({
@@ -79,7 +82,7 @@ if (response.status !== 200 || !response.data) {
 CLI equivalent: `blnk transactions list --id <transaction-id>`. See [CLI transactions](/cli/transactions).
 </Tip>
 
-See [View transaction details](/reference/get-transaction) for the full response shape.
+See [View transaction details](/reference/get-transaction) for all response fields.
 
 ---
 
@@ -105,17 +108,60 @@ if (response.status !== 200 || !response.data) {
 | :--- | :--- | :--- | :--- |
 | `reference` | string | Yes | The unique reference passed when the transaction was created. |
 
-See [Get transaction by reference](/reference/get-transaction-by-reference) for the full response shape.
+See [Get transaction by reference](/reference/get-transaction-by-reference) for all response fields.
+
+---
+
+## `getLineage`
+
+Inspect how a transaction's spend was allocated across fund providers and which internal shadow transactions Core created for lineage tracking.
+
+Most useful for debits from [lineage-enabled balances](/transactions/lineage). Returns how spend was split across providers (`fund_allocation`) and any internal shadow transactions. `fund_allocation` appears on debits from balances with `track_fund_lineage: true` when Core allocated tagged funds; it may be omitted otherwise. `shadow_transactions` may be `null` or an empty array.
+
+```typescript wrap
+const response = await blnk.Transactions.getLineage(
+  'txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad',
+);
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.transaction_id);
+  console.log(response.data.fund_allocation);
+  console.log(response.data.shadow_transactions);
+}
+```
+
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Parameters**
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `transactionId` | string | Yes | The transaction ID (for example `txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad`). |
+
+See [View transaction lineage](/reference/get-transaction-lineage) for all response fields, and the [Fund lineage guide](/transactions/lineage) for setup and concepts.
 
 ---
 
 ## `createBulk`
 
-Submit multiple transaction records in one request. Use `atomic: true` when every leg must succeed or fail together.
+Submit multiple transaction records in one request. Each item in `transactions` uses the same fields as [`create`](#create).
 
-Do not set `status` on bulk create requests. Core manages status during processing.
+For concepts, webhooks, and batch retrieval, see the [Bulk transactions guide](/transactions/bulk-transactions).
 
-For concepts and options (`inflight`, `run_async`, `skip_queue`), see the [Bulk transactions guide](/transactions/bulk-transactions).
+<Icon icon="sliders-horizontal" size={16} color="#808080" className="cli-section-icon" /> **Batch options**
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `atomic` | boolean | When `true`, every transaction in the batch succeeds or fails together. When `false`, each transaction is processed independently. |
+| `inflight` | boolean | When `true`, transactions are created in `INFLIGHT` status and require a later commit or void. When `false`, transactions post immediately (unless `run_async` is used). |
+| `run_async` | boolean | When `true`, Core processes the batch in the background and returns `status: 'queued'`. Results arrive via webhook. When `false` or omitted, processing is synchronous. |
+| `skip_queue` | boolean | When `true`, transactions bypass the queue and process synchronously. Useful for hot balances. Default: `false`. |
+| `transactions` | array | Required. Each entry must pass the same validation as a single `create` call. References must be unique within the batch. |
+
+<Tabs>
+<Tab title="Sync atomic">
+
+Set `atomic: true` when every transaction in the batch must succeed or fail together. Leave `run_async` unset for synchronous processing and an immediate response with `batch_id` and `transaction_count`.
 
 ```typescript wrap expandable
 const response = await blnk.Transactions.createBulk({
@@ -129,6 +175,7 @@ const response = await blnk.Transactions.createBulk({
       destination: '@dest_1',
       reference: 'bulk_001',
       description: 'Payment 1',
+      allow_overdraft: true,
     },
     {
       amount: 2000,
@@ -138,6 +185,7 @@ const response = await blnk.Transactions.createBulk({
       destination: '@dest_2',
       reference: 'bulk_002',
       description: 'Payment 2',
+      allow_overdraft: true,
     },
   ],
 });
@@ -149,17 +197,93 @@ if (response.status !== 201 || !response.data) {
 }
 ```
 
-See [Bulk transactions](/reference/bulk-transactions) for request and response fields.
+</Tab>
+<Tab title="Async inflight">
+
+Set `inflight: true` and `run_async: true` to create an inflight batch in the background. The response returns `status: 'queued'` and `message` instead of `transaction_count`.
+
+```typescript wrap expandable
+const response = await blnk.Transactions.createBulk({
+  atomic: true,
+  inflight: true,
+  run_async: true,
+  transactions: [
+    {
+      amount: 5000,
+      precision: 100,
+      currency: 'USD',
+      source: '@payroll_pool',
+      destination: '@employee_1',
+      reference: 'payroll_bulk_001',
+      description: 'Payroll run',
+      allow_overdraft: true,
+      inflight_expiry_date: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    },
+    {
+      amount: 3200,
+      precision: 100,
+      currency: 'USD',
+      source: '@payroll_pool',
+      destination: '@employee_2',
+      reference: 'payroll_bulk_002',
+      description: 'Payroll run',
+      allow_overdraft: true,
+      inflight_expiry_date: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    },
+  ],
+});
+
+if (response.status === 201 && response.data) {
+  console.log(response.data.batch_id, response.data.status, response.data.message);
+}
+```
+
+To commit or void the batch later, call [`updateStatus`](#updatestatus) with the `batch_id`. See [Commit or void bulk inflight](/transactions/bulk-transactions#commit-or-void-bulk-inflight).
+
+</Tab>
+<Tab title="skip_queue">
+
+Set `skip_queue: true` to process the batch synchronously without queuing. Useful for [hot balances](/guides/hot-balances).
+
+```typescript wrap
+const response = await blnk.Transactions.createBulk({
+  skip_queue: true,
+  transactions: [
+    {
+      amount: 750,
+      precision: 100,
+      currency: 'USD',
+      source: '@FundingPool',
+      destination: '@MyBalance',
+      reference: 'bulk_skip_001',
+      description: 'Hot balance payout',
+      allow_overdraft: true,
+    },
+  ],
+});
+```
+
+</Tab>
+</Tabs>
+
+See [Bulk transactions](/reference/bulk-transactions) for all request fields and response fields.
 
 ---
 
 ## `updateStatus`
 
-Commit or void an inflight transaction. Pass `status: 'commit'` to apply funds, or `status: 'void'` to cancel.
+Commit or void a single inflight transaction, or an entire inflight **batch** created with [`createBulk`](#createbulk). Pass `status: 'commit'` to apply funds, or `status: 'void'` to cancel.
 
 ```typescript wrap
+// Single inflight transaction
 const response = await blnk.Transactions.updateStatus(
   'txn_14706192-e53d-43cc-86a1-b8807a09b351',
+  { status: 'commit' },
+);
+
+// Entire inflight batch (use batch_id from createBulk)
+const batchResponse = await blnk.Transactions.updateStatus(
+  'bulk_c62f200b-905f-4983-a349-cadd279234aa',
   { status: 'commit' },
 );
 
@@ -168,7 +292,73 @@ if (response.status !== 200 || !response.data) {
 }
 ```
 
-For partial commits, include `amount` or `precise_amount`. See [Update inflight](/reference/update-inflight) and the [Inflight guide](/transactions/inflight).
+For partial commits, include `amount` or `precise_amount`. See [Update inflight](/reference/update-inflight) for all request fields and response fields, and the [Inflight guide](/transactions/inflight) for commit and void behavior.
+
+<Note>
+For independently-created inflight transactions (not from a bulk batch), use [`bulkCommitInflight`](#bulkcommitinflight) or [`bulkVoidInflight`](#bulkvoidinflight) to commit or void up to 100 at once.
+</Note>
+
+---
+
+## `bulkCommitInflight`
+
+Commit multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/commit`). Each request accepts up to 100 items.
+
+Omit `amount` and `precise_amount` on an item to commit the full remaining inflight amount. When both are set, `precise_amount` takes precedence.
+
+<Info>Available in Core 0.14.2 and later.</Info>
+
+```typescript wrap expandable
+const response = await blnk.Transactions.bulkCommitInflight({
+  transactions: [
+    { transaction_id: 'txn_11111111-1111-4111-8111-111111111111' },
+    {
+      transaction_id: 'txn_22222222-2222-4222-8222-222222222222',
+      amount: 40,
+    },
+    {
+      transaction_id: 'txn_33333333-3333-4333-8333-333333333333',
+      precise_amount: 125034,
+    },
+  ],
+});
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.succeeded, response.data.failed);
+  for (const result of response.data.results) {
+    console.log(result.transaction_id, result.status, result.code);
+  }
+}
+```
+
+See [Bulk commit inflight](/reference/bulk-commit-inflight) for all request fields and response fields, and [Bulk inflight updates](/transactions/inflight#bulk-inflight-updates) for per-item failure codes and when to use batch `updateStatus` instead.
+
+---
+
+## `bulkVoidInflight`
+
+Void multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/void`). Each request accepts up to 100 transaction IDs.
+
+<Info>Available in Core 0.14.2 and later.</Info>
+
+```typescript wrap
+const response = await blnk.Transactions.bulkVoidInflight({
+  transaction_ids: [
+    'txn_11111111-1111-4111-8111-111111111111',
+    'txn_22222222-2222-4222-8222-222222222222',
+  ],
+});
+
+if (response.status !== 200 || !response.data) {
+  console.error(`Error ${response.status}: ${response.message}`);
+} else {
+  console.log(response.data.succeeded, response.data.failed);
+}
+```
+
+See [Bulk void inflight](/reference/bulk-void-inflight) for all request fields and response fields, and [Bulk inflight updates](/transactions/inflight#bulk-inflight-updates) for per-item failure codes.
 
 ---
 
@@ -195,4 +385,4 @@ const response = await blnk.Transactions.refund(
 );
 ```
 
-See [Refund transaction](/reference/refund-transaction) and the [Refunds guide](/transactions/refunds).
+See [Refund transaction](/reference/refund-transaction) for all request fields and the response, and the [Refunds guide](/transactions/refunds) for reversal behavior.


### PR DESCRIPTION
## Summary
- Restructure all `sdks/typescript/*.mdx` resource pages with Overview, Key concepts, and per-method sections (removes "Methods at a glance" tables).
- **Search**: document Typesense vs DB filter modes, `search`, `filter`, `startReindex`, and `getReindexStatus`.
- **Identities**: add search cross-links and inline `Search.search` / `Search.filter` examples.
- **Reconciliation**: add `runInstant` section for `POST /reconciliation/start-instant`.

## Verification checklist
- [x] Typesense vs DB search called out in Search Key concepts
- [x] Search methods documented (`search`, `filter`, `startReindex`, `getReindexStatus`)
- [x] Identities has search cross-links
- [x] No "Methods at a glance" in `sdks/typescript/*.mdx`
- [x] No "Methods at a glance" in `docs.json` or nav config

## Test plan
- [x] Grep confirms no "Methods at a glance" remnants in blnk-docs
- [ ] Mintlify preview (manual)


Made with [Cursor](https://cursor.com)