### PR TITLE
fix(typescript): correct condition type from string to object on balance monitor pages

### DIFF
--- a/sdks/typescript/ledger-balances/create-balance-monitor.mdx
+++ b/sdks/typescript/ledger-balances/create-balance-monitor.mdx
@@ -30,10 +30,10 @@ const response = await blnk.BalanceMonitor.create({
 | Field | Type | Description |
 | :-- | :-- | :-- |
 | `balance_id` | `string` | Balance to monitor. |
-| `condition` | `string` | Threshold rule with `field`, `operator`, `value`, and `precision`. |
+| `condition` | `object` | Threshold rule with `field`, `operator`, `value`, and `precision`. |
 | `condition.field` | `string` | Balance field to watch (for example `credit_balance`, `debit_balance`, `balance`). |
-| `condition.operator` | `string` | Comparison operator: `>`, `<`, or `=`. |
-| `condition.value` | `string` | Threshold amount. |
+| `condition.operator` | `string` | Comparison operator: `>`, `<`, `=`, `!=`, `>=`, `<=`. |
+| `condition.value` | `number` | Threshold amount. |
 | `condition.precision` | `number` | Currency precision (for example `100` for cents). |
 | `call_back_url` | `string` | Webhook URL when the condition is met. |
 | `description` | `string` | Optional description for the monitor. |
@@ -68,7 +68,7 @@ Use `response.data.monitor_id` to retrieve or update the monitor later.
 | :-- | :-- | :-- |
 | `monitor_id` | `string` | Unique ID for the monitor. |
 | `balance_id` | `string` | Balance being monitored. |
-| `condition` | `string` | Threshold rule you passed in the request. |
+| `condition` | `object` | Threshold rule you passed in the request. |
 | `call_back_url` | `string` | Webhook URL for notifications. |
 | `description` | `string` | Description for the monitor. |
 | `created_at` | `string` | Date and time when the monitor was created. |

--- a/sdks/typescript/ledger-balances/edit-balance-monitor.mdx
+++ b/sdks/typescript/ledger-balances/edit-balance-monitor.mdx
@@ -33,7 +33,11 @@ const response = await blnk.BalanceMonitor.update(
 | :-- | :-- | :-- |
 | `id` | `string` | Monitor ID to update. |
 | `balance_id` | `string` | Balance to monitor. |
-| `condition` | `string` | Threshold rule with `field`, `operator`, `value`, and `precision`. |
+| `condition` | `object` | Threshold rule with `field`, `operator`, `value`, and `precision`. |
+| `condition.field` | `string` | Balance field to watch (for example `credit_balance`, `debit_balance`, `balance`). |
+| `condition.operator` | `string` | Comparison operator: `>`, `<`, `=`, `!=`, `>=`, `<=`. |
+| `condition.value` | `number` | Threshold amount. |
+| `condition.precision` | `number` | Currency precision (for example `100` for cents). |
 | `call_back_url` | `string` | Webhook URL when the condition is met. |
 | `description` | `string` | Optional description for the monitor. |
 

--- a/sdks/typescript/ledger-balances/get-balance-monitor.mdx
+++ b/sdks/typescript/ledger-balances/get-balance-monitor.mdx
@@ -53,7 +53,11 @@ Read `response.data` for the threshold condition, webhook URL, and linked `balan
 | :-- | :-- | :-- |
 | `monitor_id` | `string` | Unique ID for the monitor. |
 | `balance_id` | `string` | Balance being monitored. |
-| `condition` | `string` | Threshold rule for the monitor. |
+| `condition` | `object` | Threshold rule for the monitor. |
+| `condition.field` | `string` | Balance field to watch (for example `credit_balance`, `debit_balance`, `balance`). |
+| `condition.operator` | `string` | Comparison operator: `>`, `<`, `=`, `!=`, `>=`, `<=`. |
+| `condition.value` | `number` | Threshold amount. |
+| `condition.precision` | `number` | Currency precision (for example `100` for cents). |
 | `call_back_url` | `string` | Webhook URL for notifications. |
 | `description` | `string` | Description for the monitor. |
 | `created_at` | `string` | Date and time when the monitor was created. |


### PR DESCRIPTION
## Summary

- `condition` was incorrectly typed as `string` on the TypeScript SDK balance monitor pages — it is an `object` with `field`, `operator`, `value`, and `precision`
- Also fixes `condition.value` type (`string` → `number`) and expands the operator list on the create page to include `!=`, `>=`, `<=`

## Pages changed

- `sdks/typescript/ledger-balances/get-balance-monitor.mdx`
- `sdks/typescript/ledger-balances/create-balance-monitor.mdx`
- `sdks/typescript/ledger-balances/edit-balance-monitor.mdx`

## Test plan

- [ ] Preview all three pages on Mintlify dev server
- [ ] Confirm `condition` shows as `object` with nested `condition.field`, `condition.operator`, `condition.value`, `condition.precision` rows