### PR TITLE
docs(typescript): document SDK 1.3.0 for Core 0.15.0

### DIFF
--- a/balances/balance-monitoring.mdx
+++ b/balances/balance-monitoring.mdx
@@ -313,12 +313,16 @@ monitor, resp, err := client.BalanceMonitor.Update("mon_e0e77b0c-4985-472a-9bf5-
 
 ## Delete a balance monitor
 
-Call `DELETE /balance-monitors/{monitor_id}` to remove a monitor, or use [`blnk.BalanceMonitor.delete`](/sdks/typescript/ledger-balances/delete-balance-monitor) in the TypeScript SDK.
+Call `DELETE /balance-monitors/{monitor_id}` to remove a monitor.
 
 <CodeGroup>
 ```bash cURL wrap
 curl -X DELETE "http://YOUR_BLNK_INSTANCE_URL/balance-monitors/{monitor_id}" \
   -H "X-blnk-key: <api-key>"
+```
+
+```typescript TypeScript wrap
+const response = await blnk.BalanceMonitor.delete('mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0');
 ```
 </CodeGroup>
 

--- a/balances/balance-monitoring.mdx
+++ b/balances/balance-monitoring.mdx
@@ -313,7 +313,7 @@ monitor, resp, err := client.BalanceMonitor.Update("mon_e0e77b0c-4985-472a-9bf5-
 
 ## Delete a balance monitor
 
-Call `DELETE /balance-monitors/{monitor_id}` to remove a monitor.
+Call `DELETE /balance-monitors/{monitor_id}` to remove a monitor, or use [`blnk.BalanceMonitor.delete`](/sdks/typescript/ledger-balances/delete-balance-monitor) in the TypeScript SDK.
 
 <CodeGroup>
 ```bash cURL wrap

--- a/changelog/blnk-ts.mdx
+++ b/changelog/blnk-ts.mdx
@@ -14,35 +14,36 @@ description: "Latest releases, fixes, and improvements to the Blnk TypeScript SD
 
   ### Identities
 
-  Delete identities by ID with `Identity.delete`.
+  Delete identities when you need to remove a customer or organization record from your ledger.
 
   ### Balance monitors
 
-  Delete balance monitors by ID with `BalanceMonitor.delete`.
+  Remove balance monitors you no longer need. Blnk stops evaluating thresholds and sending webhooks for deleted monitors.
 
   ### Reconciliation
 
-  `Reconciliation.run` now returns only `reconciliation_id`. Listen for `reconciliation.completed` or `reconciliation.failed` webhooks for final status.
+  Start a reconciliation run and receive a reconciliation ID. Final status arrives through `reconciliation.completed` or `reconciliation.failed` webhooks instead of the start response.
 
   ### Inflight
 
-  Commit and void are queued by Core 0.15.0 by default. Responses include `queued` where applicable. Pass `skip_queue: true` on `updateStatus`, `bulkCommitInflight`, and `bulkVoidInflight` when you need synchronous `APPLIED` or `VOID` responses.
+  Commit or void inflight transactions from the SDK. On Core 0.15.0 these operations are queued by default, so the response may include a queued flag while the worker applies the change.
 
-  Bulk create enforces a maximum of **10,000** transactions per request. The `MAX_BULK_CREATE_ITEMS` constant is exported from the package.
+  Pass `skip_queue` when you need the previous synchronous behavior and an immediate applied or void result.
+
+  Bulk create supports up to **10,000** transactions per request.
 
   ### Error handling
 
-  Core error responses include structured `error_detail`. The SDK surfaces this on `response.error.code`. Empty `DELETE` bodies no longer throw during JSON parsing.
+  Core returns structured error codes in `error_detail`. The SDK exposes them on the response so you can branch on stable codes instead of message text. Empty delete responses no longer fail during JSON parsing.
 
   ### Before you upgrade
 
   Note the following breaking changes:
 
-  - `RunReconResp` is now `{ reconciliation_id: string }` instead of extending `Matcher`.
-  - `CreateTransactionResponse.rate` and `LedgerBalanceResp.currency_multiplier` are optional. Core 0.15.0 no longer returns these fields.
-  - Search balance and transaction document types no longer include `rate` or `currency_multiplier`.
-  - `UpdateTransactionStatus`, `BulkCommitInflightRequest`, and `BulkVoidInflightRequest` accept optional `skip_queue`.
-  - Branch on `response.error?.code` for Core failures. Do not parse `error` message text.
+  - Reconciliation start returns only `reconciliation_id`. Poll with `Reconciliation.get` or listen for webhooks for results.
+  - Transaction and balance responses no longer include `rate` or `currency_multiplier` from Core 0.15.0.
+  - Inflight commit and void are queued by default unless you pass `skip_queue`.
+  - Branch on `response.error?.code` for Core failures. Do not parse error message text.
 </Update>
 
 <Update label="1.2.0" description="Jun 23, 2026">

--- a/changelog/blnk-ts.mdx
+++ b/changelog/blnk-ts.mdx
@@ -9,40 +9,40 @@ description: "Latest releases, fixes, and improvements to the Blnk TypeScript SD
 
 <Update label="1.3.0" description="Jun 24, 2026">
   <Info>
-  `blnk-typescript@1.3.0` targets Blnk Core **0.15.0**.
+  `blnk-typescript@1.3.0` covers Blnk Core **0.15.0**.
   </Info>
 
   ### Identities
 
-  Delete identities when you need to remove a customer or organization record from your ledger.
+  Delete identities from the SDK when you need to remove a customer or organization from your ledger.
 
   ### Balance monitors
 
-  Remove balance monitors you no longer need. Blnk stops evaluating thresholds and sending webhooks for deleted monitors.
+  Remove balance monitors you no longer need. Blnk stops checking thresholds and sending webhooks for them.
 
   ### Reconciliation
 
-  Start a reconciliation run and receive a reconciliation ID. Final status arrives through `reconciliation.completed` or `reconciliation.failed` webhooks instead of the start response.
+  Start a reconciliation run and get back a reconciliation ID. Check final status with webhooks or `Reconciliation.get`.
 
   ### Inflight
 
-  Commit or void inflight transactions from the SDK. On Core 0.15.0 these operations are queued by default, so the response may include a queued flag while the worker applies the change.
+  Commit or void inflight transactions from the SDK. On Core 0.15.0, these run through the queue by default.
 
-  Pass `skip_queue` when you need the previous synchronous behavior and an immediate applied or void result.
+  Pass `skip_queue` when you need an immediate applied or void result.
+
+  ### Transactions
 
   Bulk create supports up to **10,000** transactions per request.
 
   ### Error handling
 
-  Core returns structured error codes in `error_detail`. The SDK exposes them on the response so you can branch on stable codes instead of message text. Empty delete responses no longer fail during JSON parsing.
+  Core returns structured error codes. The SDK puts them on the response so you can handle failures without parsing message text.
 
   ### Before you upgrade
 
   Note the following breaking changes:
 
-  - Reconciliation start returns only `reconciliation_id`. Poll with `Reconciliation.get` or listen for webhooks for results.
-  - Transaction and balance responses no longer include `rate` or `currency_multiplier` from Core 0.15.0.
-  - Inflight commit and void are queued by default unless you pass `skip_queue`.
+  - Transaction and balance responses no longer include `rate` or `currency_multiplier`.
   - Branch on `response.error?.code` for Core failures. Do not parse error message text.
 </Update>
 

--- a/changelog/blnk-ts.mdx
+++ b/changelog/blnk-ts.mdx
@@ -7,6 +7,44 @@ description: "Latest releases, fixes, and improvements to the Blnk TypeScript SD
 "og:description": "Track releases, fixes, and version history for the official Blnk TypeScript SDK."
 ---
 
+<Update label="1.3.0" description="Jun 24, 2026">
+  <Info>
+  `blnk-typescript@1.3.0` targets Blnk Core **0.15.0**.
+  </Info>
+
+  ### Identities
+
+  Delete identities by ID with `Identity.delete`.
+
+  ### Balance monitors
+
+  Delete balance monitors by ID with `BalanceMonitor.delete`.
+
+  ### Reconciliation
+
+  `Reconciliation.run` now returns only `reconciliation_id`. Listen for `reconciliation.completed` or `reconciliation.failed` webhooks for final status.
+
+  ### Inflight
+
+  Commit and void are queued by Core 0.15.0 by default. Responses include `queued` where applicable. Pass `skip_queue: true` on `updateStatus`, `bulkCommitInflight`, and `bulkVoidInflight` when you need synchronous `APPLIED` or `VOID` responses.
+
+  Bulk create enforces a maximum of **10,000** transactions per request. The `MAX_BULK_CREATE_ITEMS` constant is exported from the package.
+
+  ### Error handling
+
+  Core error responses include structured `error_detail`. The SDK surfaces this on `response.error.code`. Empty `DELETE` bodies no longer throw during JSON parsing.
+
+  ### Before you upgrade
+
+  Note the following breaking changes:
+
+  - `RunReconResp` is now `{ reconciliation_id: string }` instead of extending `Matcher`.
+  - `CreateTransactionResponse.rate` and `LedgerBalanceResp.currency_multiplier` are optional. Core 0.15.0 no longer returns these fields.
+  - Search balance and transaction document types no longer include `rate` or `currency_multiplier`.
+  - `UpdateTransactionStatus`, `BulkCommitInflightRequest`, and `BulkVoidInflightRequest` accept optional `skip_queue`.
+  - Branch on `response.error?.code` for Core failures. Do not parse `error` message text.
+</Update>
+
 <Update label="1.2.0" description="Jun 23, 2026">
   <Info>
   `blnk-typescript@1.2.0` covers the rest of Core (up until `0.14.5`).

--- a/docs.json
+++ b/docs.json
@@ -726,7 +726,8 @@
                   "sdks/typescript/ledger-balances/create-balance-monitor",
                   "sdks/typescript/ledger-balances/get-balance-monitor",
                   "sdks/typescript/ledger-balances/list-balance-monitors",
-                  "sdks/typescript/ledger-balances/edit-balance-monitor"
+                  "sdks/typescript/ledger-balances/edit-balance-monitor",
+                  "sdks/typescript/ledger-balances/delete-balance-monitor"
                 ]
               },
               {
@@ -767,7 +768,8 @@
                   "sdks/typescript/identities/detokenize-identity",
                   "sdks/typescript/identities/get-tokenized-fields",
                   "sdks/typescript/identities/tokenize-field",
-                  "sdks/typescript/identities/detokenize-field"
+                  "sdks/typescript/identities/detokenize-field",
+                  "sdks/typescript/identities/delete-identity"
                 ]
               },
               {
@@ -1189,6 +1191,11 @@
       "permanent": true
     },
     {
+      "source": "/sdks/typescript/methods/identities/delete-identity",
+      "destination": "/sdks/typescript/identities/delete-identity",
+      "permanent": true
+    },
+    {
       "source": "/sdks/typescript/methods/ledger-balances/balance-from-source",
       "destination": "/sdks/typescript/ledger-balances/balance-from-source",
       "permanent": true
@@ -1211,6 +1218,11 @@
     {
       "source": "/sdks/typescript/methods/ledger-balances/edit-balance-monitor",
       "destination": "/sdks/typescript/ledger-balances/edit-balance-monitor",
+      "permanent": true
+    },
+    {
+      "source": "/sdks/typescript/methods/ledger-balances/delete-balance-monitor",
+      "destination": "/sdks/typescript/ledger-balances/delete-balance-monitor",
       "permanent": true
     },
     {

--- a/identities/introduction.mdx
+++ b/identities/introduction.mdx
@@ -306,7 +306,7 @@ identity, resp, err := client.Identity.Update("idt_8cc22560-5ace-4989-8953-fcbad
 
 ## Delete an identity
 
-To delete an identity, call the [Delete identity](/reference/delete-identity) endpoint:
+To delete an identity, call the [Delete identity](/reference/delete-identity) endpoint or use [`blnk.Identity.delete`](/sdks/typescript/identities/delete-identity) in the TypeScript SDK:
 
 
 <CodeGroup>

--- a/identities/introduction.mdx
+++ b/identities/introduction.mdx
@@ -306,13 +306,17 @@ identity, resp, err := client.Identity.Update("idt_8cc22560-5ace-4989-8953-fcbad
 
 ## Delete an identity
 
-To delete an identity, call the [Delete identity](/reference/delete-identity) endpoint or use [`blnk.Identity.delete`](/sdks/typescript/identities/delete-identity) in the TypeScript SDK:
+To delete an identity, call the [Delete identity](/reference/delete-identity) endpoint:
 
 
 <CodeGroup>
 ```bash cURL wrap
 curl -X DELETE "http://YOUR_BLNK_INSTANCE_URL/identities/{identity_id}" \
   -H "X-blnk-key: <api-key>"
+```
+
+```typescript TypeScript wrap
+const response = await blnk.Identity.delete('idt_8cc22560-5ace-4989-8953-fcbad7947d48');
 ```
 </CodeGroup>
 

--- a/sdks/typescript/identities/delete-identity.mdx
+++ b/sdks/typescript/identities/delete-identity.mdx
@@ -14,9 +14,7 @@ Use `blnk.Identity.delete` to permanently remove an [identity](/identities/intro
 <Step title="Call the method">
 
 ```typescript blnk.Identity.delete wrap
-const response = await blnk.Identity.delete(
-  'idt_3b63c8da-af29-4cc3-ad38-df17d87456e6',
-);
+const response = await blnk.Identity.delete('idt_3b63c8da-af29-4cc3-ad38-df17d87456e6');
 ```
 
 | Field | Type | Description |
@@ -27,7 +25,7 @@ const response = await blnk.Identity.delete(
 
 <Step title="Confirm the outcome">
 
-Check `response.status` and `response.data.message` to confirm the identity was removed. A later `blnk.Identity.get` for the same ID returns `404` with `IDT_NOT_FOUND`.
+Check the response message to confirm the identity was removed. Blnk will no longer return this identity on subsequent requests.
 
 </Step>
 

--- a/sdks/typescript/identities/delete-identity.mdx
+++ b/sdks/typescript/identities/delete-identity.mdx
@@ -1,0 +1,65 @@
+---
+mode: "wide"
+title: "Delete identity"
+sidebarTitle: "Delete identity"
+api: "DELETE /identities/{identity_id}"
+description: "Delete an identity with the TypeScript SDK."
+---
+
+import NeedHelp from "/snippets/need-help.mdx";
+
+Use `blnk.Identity.delete` to permanently remove an [identity](/identities/introduction) by its ID.
+
+<Steps>
+<Step title="Call the method">
+
+```typescript blnk.Identity.delete wrap
+const response = await blnk.Identity.delete(
+  'idt_3b63c8da-af29-4cc3-ad38-df17d87456e6',
+);
+```
+
+| Field | Type | Description |
+| :-- | :-- | :-- |
+| `id` | `string` | Identity ID to delete. |
+
+</Step>
+
+<Step title="Confirm the outcome">
+
+Check `response.status` and `response.data.message` to confirm the identity was removed. A later `blnk.Identity.get` for the same ID returns `404` with `IDT_NOT_FOUND`.
+
+</Step>
+
+<Step title="Response">
+
+```json 200 OK wrap
+{
+  "message": "Identity deleted successfully"
+}
+```
+
+| Field | Type | Description |
+| :-- | :-- | :-- |
+| `message` | `string` | Confirmation that the identity was deleted. |
+
+</Step>
+</Steps>
+
+---
+
+## Related docs
+
+<CardGroup cols={2}>
+<Card title="Identity overview" icon="user-round" href="/identities/introduction">
+How identities work and when to use them.
+</Card>
+
+<Card title="Delete identity" icon="book-open" href="/reference/delete-identity">
+HTTP request and response schema.
+</Card>
+</CardGroup>
+
+---
+
+<NeedHelp />

--- a/sdks/typescript/ledger-balances/delete-balance-monitor.mdx
+++ b/sdks/typescript/ledger-balances/delete-balance-monitor.mdx
@@ -14,9 +14,7 @@ Use `blnk.BalanceMonitor.delete` to remove a [balance monitor](/balances/balance
 <Step title="Call the method">
 
 ```typescript blnk.BalanceMonitor.delete wrap
-const response = await blnk.BalanceMonitor.delete(
-  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
-);
+const response = await blnk.BalanceMonitor.delete('mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0');
 ```
 
 | Field | Type | Description |
@@ -27,7 +25,7 @@ const response = await blnk.BalanceMonitor.delete(
 
 <Step title="Confirm the outcome">
 
-Check `response.status` and `response.data.message` to confirm the monitor was removed. A later `blnk.BalanceMonitor.get` for the same ID returns `404` with `BAL_MONITOR_NOT_FOUND`.
+Check the response message to confirm the monitor was removed. Blnk will no longer check thresholds or send webhooks for that monitor.
 
 </Step>
 

--- a/sdks/typescript/ledger-balances/delete-balance-monitor.mdx
+++ b/sdks/typescript/ledger-balances/delete-balance-monitor.mdx
@@ -1,0 +1,65 @@
+---
+mode: "wide"
+title: "Delete balance monitor"
+sidebarTitle: "Delete balance monitor"
+api: "DELETE /balance-monitors/{monitor_id}"
+description: "Delete a balance monitor with the TypeScript SDK."
+---
+
+import NeedHelp from "/snippets/need-help.mdx";
+
+Use `blnk.BalanceMonitor.delete` to remove a [balance monitor](/balances/balance-monitoring) by its ID.
+
+<Steps>
+<Step title="Call the method">
+
+```typescript blnk.BalanceMonitor.delete wrap
+const response = await blnk.BalanceMonitor.delete(
+  'mon_e0e77b0c-4985-472a-9bf5-76a48b0259b0',
+);
+```
+
+| Field | Type | Description |
+| :-- | :-- | :-- |
+| `id` | `string` | Monitor ID to delete. |
+
+</Step>
+
+<Step title="Confirm the outcome">
+
+Check `response.status` and `response.data.message` to confirm the monitor was removed. A later `blnk.BalanceMonitor.get` for the same ID returns `404` with `BAL_MONITOR_NOT_FOUND`.
+
+</Step>
+
+<Step title="Response">
+
+```json 200 OK wrap
+{
+  "message": "BalanceMonitor deleted successfully"
+}
+```
+
+| Field | Type | Description |
+| :-- | :-- | :-- |
+| `message` | `string` | Confirmation that the monitor was deleted. |
+
+</Step>
+</Steps>
+
+---
+
+## Related docs
+
+<CardGroup cols={2}>
+<Card title="Balance monitoring" icon="activity" href="/balances/balance-monitoring">
+Thresholds, webhooks, and monitor lifecycle.
+</Card>
+
+<Card title="Delete balance monitor" icon="book-open" href="/reference/delete-balance-monitor">
+HTTP request and response schema.
+</Card>
+</CardGroup>
+
+---
+
+<NeedHelp />

--- a/sdks/typescript/start/error-handling.mdx
+++ b/sdks/typescript/start/error-handling.mdx
@@ -53,15 +53,16 @@ Confirm success before you use `data`. On every call, check that `status` is in 
 ```typescript Error handling wrap
 const response = await blnk.Transactions.get('txn_f482a1b3-6c2d-4e89-a17b-3d5e8f2a1c94');
 
-if (response.status !== 200) {
+if (response.status < 200 || response.status >= 300) {
   const errorCode = response.error?.code;
 
-  switch (errorCode) {
-    case 'TXN_NOT_FOUND':
-      // Resource not found: stop or prompt for a valid ID
+  switch (response.status) {
+    case 404:
+      // Resource not found: check errorCode (e.g. TXN_NOT_FOUND)
       break;
-    case undefined:
-      // SDK validation or transport failure: read response.message
+    case 401:
+    case 403:
+      // Auth or scope failure: check the API key
       break;
     default:
       // Log status, errorCode, and response.message
@@ -79,10 +80,10 @@ if (response.status !== 200) {
 
 Use the field that matches the failure type:
 
-- **Core rejection** (`status` is a Core HTTP error): branch on `response.error?.code`. Use `response.error?.message` or `response.data?.error` for display only.
+- **Core rejection** (`status` is a Core HTTP error and `data` is set): read `response.error?.code` for the code Core returned.
 - **SDK validation** (`status === 400` and `data` is `null`): read `response.message` and fix the payload before retrying.
 
-Route on `response.error?.code` when you need stable logic. Use `response.status` for broad handling (401, 404, 409, 5xx) when a specific code is not required.
+Route on `response.status` when you do not need code-level logic (401, 404, 409, 5xx).
 
 </Step>
 
@@ -114,18 +115,18 @@ On Core 0.15.0 and later, error bodies include `error_detail`:
 }
 ```
 
-Branch on `response.error?.code`. The `error` string is still returned for display, but message text may change between releases.
+Read the failure from `response.error?.code`. Use `response.status` to choose a broad response. Treat `response.error?.message` as display text; Core may change wording between releases. On older Core versions, `response.error?.code` may be `UNKNOWN`.
 
 | Status | When it happens | What to do |
 | :-- | :-- | :-- |
-| `404` | Resource ID or path does not exist | Check `error.code` (e.g. `TXN_NOT_FOUND`, `IDT_NOT_FOUND`) |
+| `404` | Resource ID or path does not exist | Check `response.error?.code` (e.g. `TXN_NOT_FOUND`, `IDT_NOT_FOUND`) |
 | `401` or `403` | API key, scope, or permission failure | Check the key, scopes, and whether the method requires the master key |
 | `409` | Conflict (duplicate reference, lock, or in-progress job) | Retry only if the operation is safe to repeat |
 | `400` | Core rejected the payload | Fix the request body before retrying |
 | `5xx` | Core or upstream failure | Retry later and check Core logs |
 
 <Warning>
-Do not match exact `error` strings or the `NOT_FOUND:` prefix in application logic. Branch on `response.error?.code` instead. See the [0.15.0 migration guide](/changelog/v15-migration) and [API error codes](/advanced/error-codes).
+Do not match exact `error` strings in application logic. Message text can change. Prefer `response.error?.code` for routing and `response.error?.message` for user-facing messages only. See the [0.15.0 migration guide](/changelog/v15-migration) and [API error codes](/advanced/error-codes).
 </Warning>
 
 ---

--- a/sdks/typescript/start/error-handling.mdx
+++ b/sdks/typescript/start/error-handling.mdx
@@ -9,7 +9,7 @@ import NeedHelp from "/snippets/need-help.mdx";
 
 Every SDK method returns an `ApiResponse<T>`. The SDK does not throw on API failures. Check `status` before you use `data`.
 
-On success, `data` holds the resource. On failure, `status` and `message` describe what went wrong. `data` may hold Core's error JSON or be `null`.
+On success, `data` holds the resource. On failure, `status` and `message` describe what went wrong. `error` holds structured Core error details when available. `data` may hold Core's raw error JSON or be `null`.
 
 <Tip>
 Do not wrap SDK calls in `try/catch` for API failures. Only `BlnkInit` throws when `baseUrl` is missing.
@@ -26,6 +26,11 @@ interface ApiResponse<T> {
   status: number;
   message: string;
   data: T;
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+  } | null;
 }
 ```
 
@@ -33,6 +38,7 @@ interface ApiResponse<T> {
 | :-- | :-- |
 | `status` | HTTP-style codes: 2xx success, 4xx client error, etc. |
 | `data` | Success body, or Core error JSON on rejection. May be `null`. |
+| `error` | Structured error parsed from Core's `error_detail`. Use `error.code` for logic. |
 | `message` | Human-readable description. For logs and UI only. Do not use for logic. |
 
 ---
@@ -48,18 +54,17 @@ Confirm success before you use `data`. On every call, check that `status` is in 
 const response = await blnk.Transactions.get('txn_f482a1b3-6c2d-4e89-a17b-3d5e8f2a1c94');
 
 if (response.status !== 200) {
-  const coreError = response.data?.error ?? response.message;
+  const errorCode = response.error?.code;
 
-  switch (response.status) {
-    case 404:
+  switch (errorCode) {
+    case 'TXN_NOT_FOUND':
       // Resource not found: stop or prompt for a valid ID
       break;
-    case 401:
-    case 403:
-      // Auth or scope failure: check the API key
+    case undefined:
+      // SDK validation or transport failure: read response.message
       break;
     default:
-      // Log status and coreError
+      // Log status, errorCode, and response.message
       break;
   }
   return;
@@ -74,10 +79,10 @@ if (response.status !== 200) {
 
 Use the field that matches the failure type:
 
-- **Core rejection** (`status` is a Core HTTP error and `data` is set): read `response.data.error` for the message Core returned.
+- **Core rejection** (`status` is a Core HTTP error): branch on `response.error?.code`. Use `response.error?.message` or `response.data?.error` for display only.
 - **SDK validation** (`status === 400` and `data` is `null`): read `response.message` and fix the payload before retrying.
 
-Route on `response.status` when you do not need message-level logic (401, 404, 409, 5xx).
+Route on `response.error?.code` when you need stable logic. Use `response.status` for broad handling (401, 404, 409, 5xx) when a specific code is not required.
 
 </Step>
 
@@ -94,28 +99,33 @@ Configure timeout and logging in [your SDK client](/sdks/typescript/start/using-
 
 ## Core errors
 
-When Core rejects a request, the SDK sets `status` to Core's HTTP status, `message` to the HTTP status text, and `data` to Core's JSON error body.
+When Core rejects a request, the SDK sets `status` to Core's HTTP status, `message` to the error message, `data` to Core's JSON error body, and `error` to structured details parsed from `error_detail`.
 
-On Core 0.14.x, the body is typically a single `error` string:
+On Core 0.15.0 and later, error bodies include `error_detail`:
 
 ```json 404 Not Found wrap
 {
-  "error": "Transaction with ID 'txn_f482a1b3-6c2d-4e89-a17b-3d5e8f2a1c94' not found"
+  "error": "transaction not found",
+  "error_detail": {
+    "code": "TXN_NOT_FOUND",
+    "message": "transaction not found",
+    "details": {}
+  }
 }
 ```
 
-Read the failure from `response.data.error`. Use `response.status` to choose a broad response. Treat the string as display text: Core may change wording between releases.
+Branch on `response.error?.code`. The `error` string is still returned for display, but message text may change between releases.
 
 | Status | When it happens | What to do |
 | :-- | :-- | :-- |
-| `404` | Resource ID or path does not exist | Stop, or ask for a valid ID |
+| `404` | Resource ID or path does not exist | Check `error.code` (e.g. `TXN_NOT_FOUND`, `IDT_NOT_FOUND`) |
 | `401` or `403` | API key, scope, or permission failure | Check the key, scopes, and whether the method requires the master key |
 | `409` | Conflict (duplicate reference, lock, or in-progress job) | Retry only if the operation is safe to repeat |
 | `400` | Core rejected the payload | Fix the request body before retrying |
 | `5xx` | Core or upstream failure | Retry later and check Core logs |
 
 <Warning>
-Do not match exact `error` strings in application logic. Message text can change. Prefer `status` for routing, and use `data.error` for user-facing messages only.
+Do not match exact `error` strings or the `NOT_FOUND:` prefix in application logic. Branch on `response.error?.code` instead. See the [0.15.0 migration guide](/changelog/v15-migration) and [API error codes](/advanced/error-codes).
 </Warning>
 
 ---
@@ -129,6 +139,7 @@ Some methods validate input before sending a request. When validation fails, Cor
 | `status` | `400` |
 | `message` | Validation error string, e.g. `reference field must be a valid string` |
 | `data` | `null` |
+| `error` | `null` |
 
 <Tip>
 Each [Core API](/sdks/typescript/ledgers/create-ledger) lists required fields for that call.
@@ -149,6 +160,10 @@ When debugging transport failures, log `status`, `message`, and the endpoint you
 <CardGroup cols={2}>
 <Card title="Using the SDK" icon="code" href="/sdks/typescript/start/using-the-sdk">
 Timeouts, retries, and logging.
+</Card>
+
+<Card title="0.15.0 migration" icon="arrow-right" href="/changelog/v15-migration">
+Error codes, inflight queuing, and reconciliation changes.
 </Card>
 
 <Card title="Quick start" icon="rocket" href="/sdks/typescript/start/quick-start">


### PR DESCRIPTION
## Summary
- Add `Identity.delete` and `BalanceMonitor.delete` TypeScript SDK method pages.
- Update error handling guide for Core 0.15 `error_detail.code` on `response.error`.
- Add SDK 1.3.0 changelog entry in `changelog/blnk-ts.mdx`.
- Link core identity and balance-monitoring guides to the new SDK pages.

## Test plan
- [ ] Mintlify preview renders new method pages and nav entries
- [ ] Error handling examples match SDK 1.3.0 `ApiResponse` shape
- [ ] Changelog 1.3.0 entry reads consistently with 1.2.0 tone