### PR TITLE
docs(typescript): show ApiResponse shape in Core errors example

### DIFF
--- a/sdks/typescript/start/error-handling.mdx
+++ b/sdks/typescript/start/error-handling.mdx
@@ -100,22 +100,34 @@ Configure timeout and logging in [your SDK client](/sdks/typescript/start/using-
 
 ## Core errors
 
-When Core rejects a request, the SDK sets `status` to Core's HTTP status, `message` to the error message, `data` to Core's JSON error body, and `error` to structured details parsed from `error_detail`.
+When Core rejects a request, the SDK wraps the failure in an `ApiResponse`. It sets `status` to Core's HTTP status, `message` to the error message, `data` to Core's JSON error body, and `error` to structured details parsed from `error_detail`.
 
-On Core 0.15.0 and later, error bodies include `error_detail`:
+On Core 0.15.0 and later, a rejected request looks like this:
 
-```json 404 Not Found wrap
+```typescript 404 Not Found wrap
+const response = await blnk.Transactions.get('txn_missing');
+
+// response:
 {
-  "error": "transaction not found",
-  "error_detail": {
-    "code": "TXN_NOT_FOUND",
-    "message": "transaction not found",
-    "details": {}
+  status: 404,
+  message: 'transaction not found',
+  data: {
+    error: 'transaction not found',
+    error_detail: {
+      code: 'TXN_NOT_FOUND',
+      message: 'transaction not found',
+      details: {}
+    }
+  },
+  error: {
+    code: 'TXN_NOT_FOUND',
+    message: 'transaction not found',
+    details: {}
   }
 }
 ```
 
-Read the failure from `response.error?.code`. Use `response.status` to choose a broad response. Treat `response.error?.message` as display text; Core may change wording between releases. On older Core versions, `response.error?.code` may be `UNKNOWN`.
+Read the failure from `response.error?.code`. Use `response.status` to choose a broad response. Treat `response.error?.message` as display text; Core may change wording between releases. On older Core versions, `response.error?.code` may be `UNKNOWN`. See [API error codes](/advanced/error-codes) for every code and its meaning.
 
 | Status | When it happens | What to do |
 | :-- | :-- | :-- |
@@ -126,7 +138,7 @@ Read the failure from `response.error?.code`. Use `response.status` to choose a 
 | `5xx` | Core or upstream failure | Retry later and check Core logs |
 
 <Warning>
-Do not match exact `error` strings in application logic. Message text can change. Prefer `response.error?.code` for routing and `response.error?.message` for user-facing messages only. See the [0.15.0 migration guide](/changelog/v15-migration) and [API error codes](/advanced/error-codes).
+Do not match exact `error` strings in application logic. Message text can change. Prefer `response.error?.code` for routing and `response.error?.message` for user-facing messages only. See the [0.15.0 migration guide](/changelog/v15-migration) if you parse error text today.
 </Warning>
 
 ---

--- a/sdks/typescript/start/error-handling.mdx
+++ b/sdks/typescript/start/error-handling.mdx
@@ -127,7 +127,7 @@ const response = await blnk.Transactions.get('txn_missing');
 }
 ```
 
-Read the failure from `response.error?.code`. Use `response.status` to choose a broad response. Treat `response.error?.message` as display text; Core may change wording between releases. On older Core versions, `response.error?.code` may be `UNKNOWN`. See [API error codes](/advanced/error-codes) for every code and its meaning.
+Read the failure from `response.error?.code`. Use `response.status` to choose a broad response. Treat `response.error?.message` as display text; Core may change wording between releases. On older Core versions, `response.error?.code` may be `UNKNOWN`.
 
 | Status | When it happens | What to do |
 | :-- | :-- | :-- |
@@ -138,7 +138,7 @@ Read the failure from `response.error?.code`. Use `response.status` to choose a 
 | `5xx` | Core or upstream failure | Retry later and check Core logs |
 
 <Warning>
-Do not match exact `error` strings in application logic. Message text can change. Prefer `response.error?.code` for routing and `response.error?.message` for user-facing messages only. See the [0.15.0 migration guide](/changelog/v15-migration) if you parse error text today.
+Do not match exact `error` strings in application logic. Message text can change. Prefer `response.error?.code` for routing and `response.error?.message` for user-facing messages only. See the [0.15.0 migration guide](/changelog/v15-migration) and [API error codes](/advanced/error-codes).
 </Warning>
 
 ---


### PR DESCRIPTION
## Summary
- Replace the raw Core JSON snippet in the TypeScript SDK error handling guide with the full `ApiResponse` envelope returned by the SDK.
- Add a single link to the API error codes catalogue after the example so `response.error?.code` guidance has a clear reference.
- Trim the warning callout to avoid duplicating the error codes link.

## Test plan
- [ ] Open `/sdks/typescript/start/error-handling` and confirm the Core errors example shows `status`, `message`, `data`, and `error`.
- [ ] Verify the API error codes link resolves to `/advanced/error-codes`.
- [ ] Confirm the warning box links only to the 0.15.0 migration guide.