### PR TITLE
docs: update lock duration default and remove apps private beta note

### DIFF
--- a/advanced/configuration/reference.mdx
+++ b/advanced/configuration/reference.mdx
@@ -56,7 +56,7 @@ BLNK_TYPESENSE_KEY=blnk-api-key
 BLNK_TRANSACTION_BATCH_SIZE=1000
 BLNK_TRANSACTION_MAX_QUEUE_SIZE=1000
 BLNK_TRANSACTION_MAX_WORKERS=10
-BLNK_TRANSACTION_LOCK_DURATION=30m
+BLNK_TRANSACTION_LOCK_DURATION=1m
 BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT=3s
 BLNK_TRANSACTION_INDEX_QUEUE_PREFIX=transactions
 BLNK_TRANSACTION_ENABLE_COALESCING=true
@@ -157,7 +157,7 @@ BLNK_S3_REGION=
     "batch_size": 1000,
     "max_queue_size": 1000,
     "max_workers": 10,
-    "lock_duration": 1800,
+    "lock_duration": 60,
     "lock_wait_timeout": 3,
     "index_queue_prefix": "transactions",
     "enable_coalescing": true,

--- a/advanced/configuration/transactions.mdx
+++ b/advanced/configuration/transactions.mdx
@@ -105,14 +105,14 @@ Use these settings to control [distributed balance locks](/guides/concurrency#di
 
 <CodeGroup>
 ```bash blnk.env
-BLNK_TRANSACTION_LOCK_DURATION=30m
+BLNK_TRANSACTION_LOCK_DURATION=1m
 BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT=3s
 ```
 
 ```json blnk.json
 {
   "transaction": {
-    "lock_duration": 1800,
+    "lock_duration": 60,
     "lock_wait_timeout": 3
   }
 }
@@ -121,7 +121,7 @@ BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT=3s
 
 | | Description | Default |
 | :-- | :-- | :-- |
-| `BLNK_TRANSACTION_LOCK_DURATION` | How long a distributed balance lock can live once acquired, in **seconds** (non-zero values). | `1800` |
+| `BLNK_TRANSACTION_LOCK_DURATION` | How long a distributed balance lock can live once acquired, in **seconds** (non-zero values). | `60` |
 | `BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT` | How long Blnk waits when acquiring **transaction balance locks** (shared path for direct and queued processing, including coalesced batch execution), in **seconds**. | `3` |
 
 ### `BLNK_TRANSACTION_LOCK_WAIT_TIMEOUT`

--- a/cloud/apps/app-logic.mdx
+++ b/cloud/apps/app-logic.mdx
@@ -9,11 +9,6 @@ og:description: "Use Cloud APIs to read data, perform actions, and create alerts
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 After installation, your app now has what it needs to work with the selected Cloud instance. The important values come from the install record you saved earlier:
 
 - `api_key`

--- a/cloud/apps/best-practices.mdx
+++ b/cloud/apps/best-practices.mdx
@@ -9,11 +9,6 @@ og:description: "Security and reliability checklist for Custom Apps before you s
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 You have wired install, launch, and Cloud API calls. Before users rely on your app in production, use this page as a final checklist for security and reliability.
 
 ---

--- a/cloud/apps/codebase-setup.mdx
+++ b/cloud/apps/codebase-setup.mdx
@@ -9,11 +9,6 @@ og:description: "Set up the routes, secrets, and app structure you need to build
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 There is no required framework, language, or folder structure for building a Custom App.
 
 You can use any stack that works for your team. What matters is that your app has the right pieces for Blnk Cloud to install it, launch it, and let it talk to the selected Cloud instance safely.

--- a/cloud/apps/define-workflow.mdx
+++ b/cloud/apps/define-workflow.mdx
@@ -9,11 +9,6 @@ og:description: "Plan what your Custom App should do before you write code - nar
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 Before writing code, define the workflow your app should support:
 
 <Steps>

--- a/cloud/apps/how-apps-work.mdx
+++ b/cloud/apps/how-apps-work.mdx
@@ -7,10 +7,6 @@ og:title: "How Custom Apps work | Blnk Cloud Guide"
 og:description: "A mental model for how Custom Apps fit with Blnk Cloud - components, lifecycle, permissions, security, and auditability."
 ---
 
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 A Custom App is a third-party app that runs inside Blnk Cloud, scoped to a single organization and Cloud instance. 
 
 It can read ledger data, perform Core actions, talk to external systems, and surface a custom UI inside the Cloud dashboard.

--- a/cloud/apps/install-app.mdx
+++ b/cloud/apps/install-app.mdx
@@ -7,10 +7,6 @@ og:title: "Installing Custom Apps | Blnk Cloud Guide"
 og:description: "Learn how to install and activate custom apps in your Blnk Cloud workspace."
 ---
 
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 This guide shows you how to install an app from the Apps library in Blnk Cloud.
 
 When you install an app, it becomes available inside the organization and Cloud instance you selected. This means an app can be installed in one instance and unavailable in another.

--- a/cloud/apps/installation.mdx
+++ b/cloud/apps/installation.mdx
@@ -9,11 +9,6 @@ og:description: "Handle install and uninstall events for your Custom App."
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 A user finds your app in the Apps library, reviews the permissions it requests, and confirms the install. After that, Blnk Cloud sends an event to your app so you can provision the installation on your side.
 
 Here's what happens during installation:

--- a/cloud/apps/launch-app.mdx
+++ b/cloud/apps/launch-app.mdx
@@ -9,11 +9,6 @@ og:description: "Publish and launch your custom app in Blnk Cloud."
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 Now, that your app is installed and working well, you can launch it from the Cloud dashboard.
 
 Just like the install process, the launch process starts in Blnk Cloud. When a user clicks `Launch app` in Blnk Cloud:

--- a/cloud/apps/overview.mdx
+++ b/cloud/apps/overview.mdx
@@ -9,10 +9,6 @@ og:description: "What Custom Apps are, how they work in Blnk Cloud, and how to p
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 <img src="/cloud/img/apps/apps-cover.png" alt="Custom Apps cover image" className="rounded-lg" />
 
 The ledger is the source of truth for your financial records, but the work around it often happens elsewhere.

--- a/cloud/apps/register-app.mdx
+++ b/cloud/apps/register-app.mdx
@@ -9,11 +9,6 @@ og:description: "Add your Custom App to the Apps library and configure the manif
 
 import AppsHelp from "/cloud/snippets/apps-help.mdx";
 
-
-<Note>
-This feature is in private beta. If you want access, please [contact Support](mailto:support@blnkfinance.com?subject=Interested%20in%20Custom%20Apps).
-</Note>
-
 Now that you have your routes set up in your codebase, you can now add your app to Blnk Cloud. Your app needs to be registered before it can be installed by users.
 
 To register your app:


### PR DESCRIPTION
## Summary
- Update `BLNK_TRANSACTION_LOCK_DURATION` documented default from `30m` / `1800` to `1m` / `60` in configuration docs
- Remove the private beta `<Note>` callout from all Custom Apps docs pages

## Test plan
- [ ] Verify configuration examples in `transactions.mdx` and `reference.mdx` show `1m` (env) and `60` (JSON)
- [ ] Confirm no Custom Apps pages still show the private beta banner
- [ ] Mintlify preview renders apps pages without layout issues after note removal